### PR TITLE
Add client/server metadata validation

### DIFF
--- a/app/Http/Controllers/ExpedienteController.php
+++ b/app/Http/Controllers/ExpedienteController.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Dependencia;
+use App\Models\Expediente;
+use App\Models\Documento;
+use App\Models\Tramite;
+use App\Models\Facultad;
+use App\Http\Requests\ValidateExpedienteMetadataRequest;
+use App\Http\Requests\UploadDocumentsRequest;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
+
+class ExpedienteController extends Controller
+{
+    public function index(Request $request)
+    {
+        $query = Expediente::query();
+
+        if ($request->filled('tipo_tramite')) {
+            $query->where('tipo_tramite_id', $request->tipo_tramite);
+        }
+        if ($request->filled('facultad')) {
+            $query->where('facultad_id', $request->facultad);
+        }
+        if ($request->filled('desde')) {
+            $query->whereDate('fecha_expediente', '>=', $request->desde);
+        }
+        if ($request->filled('hasta')) {
+            $query->whereDate('fecha_expediente', '<=', $request->hasta);
+        }
+
+        $expedientes = $query->orderByDesc('fecha_expediente')->get();
+        $tramites = Tramite::all();
+        $facultades = Facultad::all();
+
+        return view('expedientes.index', compact('expedientes', 'tramites', 'facultades'));
+    }
+
+    public function create()
+    {
+        $dependencias = Dependencia::all();
+        $tramites = Tramite::all();
+        $facultades = Facultad::all();
+
+        return view('expedientes.create', compact('dependencias', 'tramites', 'facultades'));
+    }
+
+    public function store(ValidateExpedienteMetadataRequest $request): RedirectResponse
+    {
+        $validated = $request->validated();
+
+        $expediente = Expediente::create([
+            'nombre' => $request->input('nombre'),
+            'dependencia_id' => $request->input('dependencia'),
+            'tipo_tramite_id' => $validated['tipo_tramite'],
+            'facultad_id' => $validated['facultad'],
+            'fecha_expediente' => $validated['fecha_expediente'],
+        ]);
+
+        return redirect()
+            ->route('expedientes.show', $expediente)
+            ->with('success', __('Expediente archivado correctamente.'));
+    }
+
+    public function show(int $id)
+    {
+        $expediente = Expediente::with([
+            'documentos' => function ($query) {
+                $query->orderBy('uploaded_at');
+            },
+            'tramite',
+            'facultad',
+            'dependencia',
+        ])->findOrFail($id);
+
+        return view('expedientes.show', compact('expediente'));
+    }
+
+    public function uploadDocuments(UploadDocumentsRequest $request, int $id): RedirectResponse
+    {
+        $expediente = Expediente::findOrFail($id);
+
+        foreach ($request->file('documents') as $file) {
+            $path = $file->store('expedientes/'.$expediente->id);
+
+            $expediente->documentos()->create([
+                'ruta' => $path,
+                'size' => $file->getSize(),
+                'user_id' => $request->user()->id,
+                'uploaded_at' => now(),
+            ]);
+        }
+
+        return redirect()
+            ->route('expedientes.show', $expediente)
+            ->with('success', __('Documentos cargados correctamente.'));
+    }
+}

--- a/app/Http/Requests/StoreExpedienteMetadataRequest.php
+++ b/app/Http/Requests/StoreExpedienteMetadataRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreExpedienteMetadataRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'nombre' => ['required', 'string', 'max:255'],
+            'dependencia' => ['required', 'exists:dependencias,id'],
+            'tipo_tramite' => ['required', 'exists:tramites,id'],
+            'fecha_expediente' => ['required', 'date', 'before_or_equal:today'],
+            'facultad' => ['required', 'exists:facultades,id'],
+        ];
+    }
+}

--- a/app/Http/Requests/StoreExpedienteRequest.php
+++ b/app/Http/Requests/StoreExpedienteRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreExpedienteRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'nombre' => ['required', 'string', 'max:255'],
+            'fecha' => ['required', 'date'],
+            'dependencia' => ['required', 'exists:dependencias,id'],
+        ];
+    }
+}

--- a/app/Http/Requests/UploadDocumentsRequest.php
+++ b/app/Http/Requests/UploadDocumentsRequest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UploadDocumentsRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'documents' => ['required', 'array'],
+            'documents.*' => ['file', 'mimes:pdf', 'max:10240'],
+        ];
+    }
+}

--- a/app/Http/Requests/ValidateExpedienteMetadataRequest.php
+++ b/app/Http/Requests/ValidateExpedienteMetadataRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ValidateExpedienteMetadataRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'tipo_tramite' => ['required', 'exists:tramites,id'],
+            'fecha_expediente' => ['required', 'date', 'before_or_equal:today'],
+            'facultad' => ['required', 'exists:facultades,id'],
+        ];
+    }
+}

--- a/app/Models/Dependencia.php
+++ b/app/Models/Dependencia.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @property int $id
+ * @property string $nombre
+ */
+class Dependencia extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'nombre',
+    ];
+}

--- a/app/Models/Documento.php
+++ b/app/Models/Documento.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Documento extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'expediente_id',
+        'ruta',
+        'size',
+        'user_id',
+        'uploaded_at',
+    ];
+
+    protected $casts = [
+        'uploaded_at' => 'datetime',
+    ];
+
+    public function expediente()
+    {
+        return $this->belongsTo(Expediente::class);
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/Expediente.php
+++ b/app/Models/Expediente.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use App\Models\Documento;
+
+/**
+ * @property int $id
+ * @property string $nombre
+ * @property int $dependencia_id
+ * @property int $tipo_tramite_id
+ * @property int $facultad_id
+ * @property \Illuminate\Support\Carbon $fecha_expediente
+ */
+class Expediente extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'nombre',
+        'dependencia_id',
+        'tipo_tramite_id',
+        'facultad_id',
+        'fecha_expediente',
+    ];
+
+    protected $casts = [
+        'fecha_expediente' => 'date',
+    ];
+
+    public function dependencia()
+    {
+        return $this->belongsTo(Dependencia::class);
+    }
+
+    public function tramite()
+    {
+        return $this->belongsTo(Tramite::class, 'tipo_tramite_id');
+    }
+
+    public function facultad()
+    {
+        return $this->belongsTo(Facultad::class);
+    }
+
+    public function documentos()
+    {
+        return $this->hasMany(Documento::class);
+    }
+}

--- a/app/Models/Facultad.php
+++ b/app/Models/Facultad.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Facultad extends Model
+{
+    use HasFactory;
+
+    protected $table = 'facultades';
+
+    protected $fillable = ['nombre'];
+}

--- a/app/Models/Tramite.php
+++ b/app/Models/Tramite.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Tramite extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['nombre'];
+}

--- a/database/factories/DependenciaFactory.php
+++ b/database/factories/DependenciaFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Dependencia>
+ */
+class DependenciaFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'nombre' => fake()->company(),
+        ];
+    }
+}

--- a/database/factories/FacultadFactory.php
+++ b/database/factories/FacultadFactory.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Facultad>
+ */
+class FacultadFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'nombre' => fake()->company(),
+        ];
+    }
+}

--- a/database/factories/TramiteFactory.php
+++ b/database/factories/TramiteFactory.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Tramite>
+ */
+class TramiteFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'nombre' => fake()->word(),
+        ];
+    }
+}

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -24,8 +24,11 @@ class UserFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => fake()->name(),
+            'name' => fake()->firstName(),
+            'last_name' => fake()->lastName(),
             'email' => fake()->unique()->safeEmail(),
+            'dni' => str_pad((string) fake()->unique()->numberBetween(0, 99999999), 8, '0', STR_PAD_LEFT),
+            'role_id' => 1,
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),
             'remember_token' => Str::random(10),

--- a/database/migrations/2025_07_13_035742_create_dependencias_table.php
+++ b/database/migrations/2025_07_13_035742_create_dependencias_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('dependencias', function (Blueprint $table) {
+            $table->id();
+            $table->string('nombre');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('dependencias');
+    }
+};

--- a/database/migrations/2025_07_13_035744_create_expedientes_table.php
+++ b/database/migrations/2025_07_13_035744_create_expedientes_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('expedientes', function (Blueprint $table) {
+            $table->id();
+            $table->string('nombre');
+            $table->foreignId('dependencia_id')->constrained('dependencias');
+            $table->foreignId('tipo_tramite_id')->constrained('tramites');
+            $table->foreignId('facultad_id')->constrained('facultades');
+            $table->date('fecha_expediente');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('expedientes');
+    }
+};

--- a/database/migrations/2025_07_13_040322_create_documentos_table.php
+++ b/database/migrations/2025_07_13_040322_create_documentos_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('documentos', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('expediente_id')->constrained('expedientes');
+            $table->string('ruta');
+            $table->unsignedBigInteger('size');
+            $table->foreignId('user_id')->constrained('users');
+            $table->timestamp('uploaded_at');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('documentos');
+    }
+};

--- a/database/migrations/2025_07_13_040323_create_tramites_table.php
+++ b/database/migrations/2025_07_13_040323_create_tramites_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('tramites', function (Blueprint $table) {
+            $table->id();
+            $table->string('nombre');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('tramites');
+    }
+};

--- a/database/migrations/2025_07_13_040324_create_facultades_table.php
+++ b/database/migrations/2025_07_13_040324_create_facultades_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('facultades', function (Blueprint $table) {
+            $table->id();
+            $table->string('nombre');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('facultades');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -3,6 +3,9 @@
 namespace Database\Seeders;
 
 use App\Models\User;
+use Database\Seeders\DependenciaSeeder;
+use Database\Seeders\TramiteSeeder;
+use Database\Seeders\FacultadSeeder;
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
@@ -16,8 +19,17 @@ class DatabaseSeeder extends Seeder
         // User::factory(10)->create();
 
         User::factory()->create([
-            'name' => 'Test User',
+            'name' => 'Test',
+            'last_name' => 'User',
             'email' => 'test@example.com',
+            'dni' => '12345678',
+            'role_id' => 1,
+        ]);
+
+        $this->call([
+            DependenciaSeeder::class,
+            TramiteSeeder::class,
+            FacultadSeeder::class,
         ]);
     }
 }

--- a/database/seeders/DependenciaSeeder.php
+++ b/database/seeders/DependenciaSeeder.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Dependencia;
+
+class DependenciaSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        Dependencia::factory()->count(3)->create();
+    }
+}

--- a/database/seeders/FacultadSeeder.php
+++ b/database/seeders/FacultadSeeder.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Facultad;
+
+class FacultadSeeder extends Seeder
+{
+    public function run(): void
+    {
+        Facultad::factory()->count(3)->create();
+    }
+}

--- a/database/seeders/TramiteSeeder.php
+++ b/database/seeders/TramiteSeeder.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Tramite;
+
+class TramiteSeeder extends Seeder
+{
+    public function run(): void
+    {
+        Tramite::factory()->count(3)->create();
+    }
+}

--- a/resources/views/components/form/field.blade.php
+++ b/resources/views/components/form/field.blade.php
@@ -1,0 +1,26 @@
+@props(['label', 'name', 'errors'])
+<div class="grid gap-1">
+    <label for="{{ $name }}" class="text-sm font-medium text-gray-700 dark:text-gray-200">{{ $label }}</label>
+    <div class="relative">
+        {{ $slot }}
+        <svg
+            x-show="validation['{{ $name }}'] && validation['{{ $name }}'].valid"
+            class="pointer-events-none absolute right-2 top-1/2 size-4 -translate-y-1/2 text-green-600"
+            xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5" />
+        </svg>
+        <svg
+            x-show="validation['{{ $name }}'] && !validation['{{ $name }}'].valid"
+            class="pointer-events-none absolute right-2 top-1/2 size-4 -translate-y-1/2 text-red-600"
+            xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+        </svg>
+    </div>
+    <p
+        x-show="validation['{{ $name }}'] && !validation['{{ $name }}'].valid"
+        x-text="validation['{{ $name }}'].message"
+        class="text-sm text-red-600"></p>
+    @if($errors)
+        <p class="text-sm text-red-600">{{ $errors->first() }}</p>
+    @endif
+</div>

--- a/resources/views/components/form/upload.blade.php
+++ b/resources/views/components/form/upload.blade.php
@@ -1,0 +1,9 @@
+@props(['label', 'name' => 'documents[]', 'errors'])
+<div class="grid gap-1">
+    <label class="text-sm font-medium text-gray-700 dark:text-gray-200">{{ $label }}</label>
+    <input type="file" name="{{ $name }}" accept="application/pdf" multiple
+        class="w-full rounded border-gray-300 text-sm shadow-sm focus:border-indigo-500 focus:ring-indigo-500" />
+    @if($errors)
+        <p class="text-sm text-red-600">{{ $errors->first() }}</p>
+    @endif
+</div>

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -1,5 +1,10 @@
 <x-layouts.app :title="__('Dashboard')">
     <div class="flex h-full w-full flex-1 flex-col gap-4 rounded-xl">
+        <div class="flex justify-end">
+            <a href="{{ route('expedientes.create') }}" class="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 font-semibold text-white hover:bg-blue-700">
+                + {{ __('Nuevo expediente') }}
+            </a>
+        </div>
         <div class="grid auto-rows-min gap-4 md:grid-cols-3">
             <div class="relative aspect-video overflow-hidden rounded-xl border border-neutral-200 dark:border-neutral-700">
                 <x-placeholder-pattern class="absolute inset-0 size-full stroke-gray-900/20 dark:stroke-neutral-100/20" />

--- a/resources/views/expedientes/create.blade.php
+++ b/resources/views/expedientes/create.blade.php
@@ -1,0 +1,113 @@
+<x-layouts.app :title="__('Registrar Expediente')">
+    <div class="container mx-auto grid max-w-xl gap-6 p-6">
+        <h1 class="text-2xl font-bold">{{ __('Registrar Expediente') }}</h1>
+        <form x-data="metadatos()" @submit.prevent="submit()" novalidate method="POST" action="{{ route('expedientes.store') }}" class="grid gap-4">
+            @csrf
+            <x-form.field label="Nombre del expediente" name="nombre" :errors="$errors->get('nombre')">
+                <input id="nombre" type="text" name="nombre" value="{{ old('nombre') }}" required class="w-full rounded border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500" />
+            </x-form.field>
+
+            <x-form.field label="Dependencia de origen" name="dependencia" :errors="$errors->get('dependencia')">
+                <select id="dependencia" name="dependencia" required class="w-full rounded border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500">
+                    <option value="" disabled {{ old('dependencia') ? '' : 'selected' }}>{{ __('Seleccione') }}</option>
+                    @foreach($dependencias as $dependencia)
+                        <option value="{{ $dependencia->id }}" @selected(old('dependencia') == $dependencia->id)>{{ $dependencia->nombre }}</option>
+                    @endforeach
+                </select>
+            </x-form.field>
+
+            <h2 class="mt-4 text-lg font-semibold">{{ __('Metadatos del expediente') }}</h2>
+
+            <x-form.field label="Tipo de trámite" name="tipo_tramite" :errors="$errors->get('tipo_tramite')">
+                <select id="tipo_tramite" name="tipo_tramite"
+                    x-model="fields.tipo_tramite"
+                    @change="validate('tipo_tramite')"
+                    :class="classes('tipo_tramite')"
+                    required
+                    class="w-full rounded border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500">
+                    <option value="" disabled {{ old('tipo_tramite') ? '' : 'selected' }}>{{ __('Seleccione') }}</option>
+                    @foreach($tramites as $tramite)
+                        <option value="{{ $tramite->id }}" @selected(old('tipo_tramite') == $tramite->id)>{{ $tramite->nombre }}</option>
+                    @endforeach
+                </select>
+            </x-form.field>
+
+            <x-form.field label="Fecha del expediente" name="fecha_expediente" :errors="$errors->get('fecha_expediente')">
+                <input id="fecha_expediente" type="date" name="fecha_expediente"
+                    x-model="fields.fecha_expediente"
+                    @input="validate('fecha_expediente')"
+                    :class="classes('fecha_expediente')"
+                    value="{{ old('fecha_expediente') }}" required
+                    class="w-full rounded border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500" />
+            </x-form.field>
+
+            <x-form.field label="Facultad" name="facultad" :errors="$errors->get('facultad')">
+                <select id="facultad" name="facultad"
+                    x-model="fields.facultad"
+                    @change="validate('facultad')"
+                    :class="classes('facultad')"
+                    required
+                    class="w-full rounded border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500">
+                    <option value="" disabled {{ old('facultad') ? '' : 'selected' }}>{{ __('Seleccione') }}</option>
+                    @foreach($facultades as $facultad)
+                        <option value="{{ $facultad->id }}" @selected(old('facultad') == $facultad->id)>{{ $facultad->nombre }}</option>
+                    @endforeach
+                </select>
+            </x-form.field>
+
+            <div class="flex justify-end">
+                <button type="submit"
+                    :disabled="hasErrors"
+                    class="rounded bg-blue-600 px-4 py-2 font-semibold text-white hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed">
+                    {{ __('Guardar y archivar') }}
+                </button>
+            </div>
+        </form>
+        <script>
+            function metadatos() {
+                return {
+                    fields: {
+                        tipo_tramite: '{{ old('tipo_tramite') }}',
+                        fecha_expediente: '{{ old('fecha_expediente') }}',
+                        facultad: '{{ old('facultad') }}',
+                    },
+                    validation: {},
+                    validate(field) {
+                        const value = this.fields[field];
+                        let valid = true;
+                        let message = '';
+
+                        if (!value) {
+                            valid = false;
+                            message = '{{ __('Este campo es obligatorio.') }}';
+                        } else if (field === 'fecha_expediente') {
+                            const today = new Date().toISOString().split('T')[0];
+                            if (value > today) {
+                                valid = false;
+                                message = '{{ __('La fecha no puede ser futura.') }}';
+                            }
+                        }
+
+                        this.validation[field] = { valid, message };
+                    },
+                    classes(field) {
+                        if (!this.validation[field]) return '';
+                        return this.validation[field].valid
+                            ? 'border-green-500 focus:border-green-500 focus:ring-green-300'
+                            : 'border-red-500 focus:border-red-500 focus:ring-red-300';
+                    },
+                    get hasErrors() {
+                        return Object.values(this.validation).some(v => !v.valid);
+                    },
+                    init() {
+                        ['tipo_tramite','fecha_expediente','facultad'].forEach(f => this.validate(f));
+                    },
+                    submit() {
+                        ['tipo_tramite','fecha_expediente','facultad'].forEach(f => this.validate(f));
+                        if (!this.hasErrors) this.$el.submit();
+                    }
+                }
+            }
+        </script>
+    </div>
+</x-layouts.app>

--- a/resources/views/expedientes/index.blade.php
+++ b/resources/views/expedientes/index.blade.php
@@ -1,0 +1,61 @@
+<x-layouts.app :title="__('Expedientes')">
+    <div class="container mx-auto grid max-w-3xl gap-6 p-6">
+        <h1 class="text-2xl font-bold">{{ __('Expedientes') }}</h1>
+        <form method="GET" class="grid gap-4 md:grid-cols-3">
+            <x-form.field label="Tipo de trámite" name="tipo_tramite" :errors="null">
+                <select id="tipo_tramite" name="tipo_tramite" class="w-full rounded border-gray-300 text-sm shadow-sm focus:border-blue-500 focus:ring-blue-500">
+                    <option value="">{{ __('Todos') }}</option>
+                    @foreach($tramites as $tramite)
+                        <option value="{{ $tramite->id }}" @selected(request('tipo_tramite') == $tramite->id)>{{ $tramite->nombre }}</option>
+                    @endforeach
+                </select>
+            </x-form.field>
+            <x-form.field label="Facultad" name="facultad" :errors="null">
+                <select id="facultad" name="facultad" class="w-full rounded border-gray-300 text-sm shadow-sm focus:border-blue-500 focus:ring-blue-500">
+                    <option value="">{{ __('Todas') }}</option>
+                    @foreach($facultades as $facultad)
+                        <option value="{{ $facultad->id }}" @selected(request('facultad') == $facultad->id)>{{ $facultad->nombre }}</option>
+                    @endforeach
+                </select>
+            </x-form.field>
+            <div class="grid grid-cols-2 gap-2">
+                <x-form.field label="Desde" name="desde" :errors="null">
+                    <input id="desde" type="date" name="desde" value="{{ request('desde') }}" class="w-full rounded border-gray-300 text-sm shadow-sm focus:border-blue-500 focus:ring-blue-500" />
+                </x-form.field>
+                <x-form.field label="Hasta" name="hasta" :errors="null">
+                    <input id="hasta" type="date" name="hasta" value="{{ request('hasta') }}" class="w-full rounded border-gray-300 text-sm shadow-sm focus:border-blue-500 focus:ring-blue-500" />
+                </x-form.field>
+            </div>
+            <div class="flex items-end">
+                <button class="rounded bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700">{{ __('Filtrar') }}</button>
+            </div>
+        </form>
+
+        <div class="overflow-x-auto">
+            <table class="min-w-full text-sm">
+                <thead class="text-left font-medium text-gray-700 dark:text-gray-200">
+                    <tr>
+                        <th class="p-2">{{ __('Nombre') }}</th>
+                        <th class="p-2">{{ __('Tipo trámite') }}</th>
+                        <th class="p-2">{{ __('Facultad') }}</th>
+                        <th class="p-2">{{ __('Fecha') }}</th>
+                        <th class="p-2"></th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
+                    @foreach($expedientes as $expediente)
+                        <tr>
+                            <td class="p-2">{{ $expediente->nombre }}</td>
+                            <td class="p-2">{{ $expediente->tramite->nombre }}</td>
+                            <td class="p-2">{{ $expediente->facultad->nombre }}</td>
+                            <td class="p-2">{{ $expediente->fecha_expediente->format('Y-m-d') }}</td>
+                            <td class="p-2 text-right">
+                                <a href="{{ route('expedientes.show', $expediente) }}" class="text-blue-600 hover:underline">{{ __('Ver') }}</a>
+                            </td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
+    </div>
+</x-layouts.app>

--- a/resources/views/expedientes/show.blade.php
+++ b/resources/views/expedientes/show.blade.php
@@ -1,0 +1,56 @@
+@php use Illuminate\Support\Facades\Storage; @endphp
+<x-layouts.app :title="$expediente->nombre">
+    <div class="container mx-auto grid max-w-3xl gap-6 p-6">
+        <h1 class="text-2xl font-bold">{{ $expediente->nombre }}</h1>
+
+        <section class="grid gap-2 text-sm">
+            <div><span class="font-medium">{{ __('Tipo de trámite:') }}</span> {{ $expediente->tramite->nombre }}</div>
+            <div><span class="font-medium">{{ __('Facultad:') }}</span> {{ $expediente->facultad->nombre }}</div>
+            <div><span class="font-medium">{{ __('Fecha del expediente:') }}</span> {{ $expediente->fecha_expediente->format('Y-m-d') }}</div>
+        </section>
+
+        <section class="grid gap-4">
+            <h2 class="text-xl font-semibold">{{ __('Documentos') }}</h2>
+
+            @if(session('success'))
+                <div class="rounded bg-green-100 p-2 text-sm text-green-800">{{ session('success') }}</div>
+            @endif
+
+            <form method="POST" action="{{ route('expedientes.documents.upload', $expediente) }}" enctype="multipart/form-data" class="grid gap-4">
+                @csrf
+                <x-form.upload label="{{ __('Seleccionar documentos') }}" :errors="$errors->get('documents')" />
+                <div class="flex justify-end">
+                    <button type="submit" class="rounded bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700">+ {{ __('Cargar documentos') }}</button>
+                </div>
+            </form>
+
+            <div class="overflow-x-auto">
+                <table class="min-w-full text-sm">
+                    <thead class="text-left font-medium text-gray-700 dark:text-gray-200">
+                        <tr>
+                            <th class="p-2">{{ __('Nombre') }}</th>
+                            <th class="p-2">{{ __('Fecha') }}</th>
+                            <th class="p-2">{{ __('Hora') }}</th>
+                            <th class="p-2">{{ __('Tamaño') }}</th>
+                            <th class="p-2"></th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
+                        @foreach($expediente->documentos as $documento)
+                            <tr>
+                                <td class="p-2">{{ basename($documento->ruta) }}</td>
+                                <td class="p-2">{{ $documento->uploaded_at->format('Y-m-d') }}</td>
+                                <td class="p-2">{{ $documento->uploaded_at->format('H:i') }}</td>
+                                <td class="p-2">{{ number_format($documento->size / 1024, 2) }} KB</td>
+                                <td class="p-2 flex gap-2">
+                                    <a href="{{ Storage::url($documento->ruta) }}" target="_blank" class="text-blue-600 hover:underline">{{ __('Ver') }}</a>
+                                    <a href="{{ Storage::url($documento->ruta) }}" download class="text-blue-600 hover:underline">{{ __('Descargar') }}</a>
+                                </td>
+                            </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+        </section>
+    </div>
+</x-layouts.app>

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Support\Facades\Route;
 use Livewire\Volt\Volt;
+use App\Http\Controllers\ExpedienteController;
 
 Route::get('/', function () {
     return view('welcome');
@@ -13,6 +14,17 @@ Route::view('dashboard', 'dashboard')
 
 Route::middleware(['auth'])->group(function () {
     Route::redirect('settings', 'settings/profile');
+
+    Route::get('/expedientes', [ExpedienteController::class, 'index'])
+        ->name('expedientes.index');
+    Route::get('/expedientes/create', [ExpedienteController::class, 'create'])
+        ->name('expedientes.create');
+    Route::post('/expedientes', [ExpedienteController::class, 'store'])
+        ->name('expedientes.store');
+    Route::get('/expedientes/{expediente}', [ExpedienteController::class, 'show'])
+        ->name('expedientes.show');
+    Route::post('/expedientes/{expediente}/documents', [ExpedienteController::class, 'uploadDocuments'])
+        ->name('expedientes.documents.upload');
 
     Volt::route('settings/profile', 'settings.profile')->name('settings.profile');
     Volt::route('settings/password', 'settings.password')->name('settings.password');

--- a/tests/Feature/ExpedienteMetadataValidationTest.php
+++ b/tests/Feature/ExpedienteMetadataValidationTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Dependencia;
+use App\Models\Facultad;
+use App\Models\Tramite;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ExpedienteMetadataValidationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_metadata_fields_are_required(): void
+    {
+        $user = User::factory()->create();
+        $dependencia = Dependencia::factory()->create();
+
+        $response = $this->actingAs($user)->post('/expedientes', [
+            'nombre' => 'Expediente',
+            'dependencia' => $dependencia->id,
+        ]);
+
+        $response->assertSessionHasErrors(['tipo_tramite', 'fecha_expediente', 'facultad']);
+    }
+
+    public function test_expediente_is_stored_when_metadata_valid(): void
+    {
+        $user = User::factory()->create();
+        $dependencia = Dependencia::factory()->create();
+        $tramite = Tramite::factory()->create();
+        $facultad = Facultad::factory()->create();
+
+        $response = $this->actingAs($user)->post('/expedientes', [
+            'nombre' => 'Expediente',
+            'dependencia' => $dependencia->id,
+            'tipo_tramite' => $tramite->id,
+            'fecha_expediente' => now()->format('Y-m-d'),
+            'facultad' => $facultad->id,
+        ]);
+
+        $response->assertRedirect();
+        $this->assertDatabaseHas('expedientes', [
+            'nombre' => 'Expediente',
+            'tipo_tramite_id' => $tramite->id,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- validate expediente metadata server-side via new form request
- show live validation feedback with Alpine in create form
- update form field component to display validation state icons
- allow Facultad model to use correct table
- add feature tests for expediente metadata validation

## Testing
- `npm install`
- `npm run build`
- `APP_KEY=base64:SfZ4qej3H96D8NlDXrP+UCJOl9oTsHoxISPIbRnNV8U= php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_68732bae2a5083279b925a4a4df9f2b9