### PR TITLE
Add filters for Facultad and Tipo de trámite

### DIFF
--- a/app/Http/Controllers/ArchivoCentralController.php
+++ b/app/Http/Controllers/ArchivoCentralController.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Http\Controllers;
+
+class ArchivoCentralController extends Controller
+{
+    public function __invoke()
+    {
+        return view('archivo-central');
+    }
+}

--- a/resources/views/components/layouts/app/sidebar.blade.php
+++ b/resources/views/components/layouts/app/sidebar.blade.php
@@ -13,7 +13,7 @@
                     <li><a href="#" class="block px-4 py-2 hover:bg-green-700">Mis Asignaciones</a></li>
                     <li><a href="#" class="block px-4 py-2 hover:bg-green-700">Pendientes</a></li>
                     <li><a href="#" class="block px-4 py-2 hover:bg-green-700">Completados</a></li>
-                    <li><a href="{{ route('archivo-central') }}" class="block px-4 py-2 hover:bg-green-700 {{ request()->is('archivo-central') ? 'bg-green-700' : '' }}">Archivo Central</a></li>
+                    <li><a href="{{ route('archivo.central') }}" class="block px-4 py-2 hover:bg-green-700 {{ request()->is('archivo-central') ? 'bg-green-700' : '' }}">Archivo Central</a></li>
                 </ul>
             </nav>
         </div>

--- a/resources/views/livewire/archivo-central.blade.php
+++ b/resources/views/livewire/archivo-central.blade.php
@@ -11,31 +11,31 @@
     <div class="grid grid-cols-1 sm:grid-cols-6 gap-4 mb-4">
         <select wire:model.debounce.300ms="year" class="border rounded px-3 py-2 focus:ring focus:border-green-300">
             <option value="">Año</option>
-            @foreach($this->years as $y)
+            @foreach($years as $y)
                 <option value="{{ $y }}">{{ $y }}</option>
             @endforeach
         </select>
         <select wire:model.debounce.300ms="month" class="border rounded px-3 py-2 focus:ring focus:border-green-300">
             <option value="">Mes</option>
-            @foreach($this->months as $num => $name)
+            @foreach($months as $num => $name)
                 <option value="{{ $num }}">{{ $name }}</option>
             @endforeach
         </select>
         <select wire:model.debounce.300ms="faculty" class="border rounded px-3 py-2 focus:ring focus:border-green-300">
             <option value="">Facultad</option>
-            @foreach($this->faculties as $id => $name)
-                <option value="{{ $id }}">{{ $name }}</option>
+            @foreach($facultades as $f)
+                <option value="{{ $f }}">{{ $f }}</option>
             @endforeach
         </select>
         <select wire:model.debounce.300ms="type" class="border rounded px-3 py-2 focus:ring focus:border-green-300">
             <option value="">Tipo de trámite</option>
-            @foreach($this->types as $id => $name)
-                <option value="{{ $id }}">{{ $name }}</option>
+            @foreach($tiposTramite as $t)
+                <option value="{{ $t }}">{{ $t }}</option>
             @endforeach
         </select>
         <select wire:model.debounce.300ms="state" class="border rounded px-3 py-2 focus:ring focus:border-green-300">
             <option value="">Estado</option>
-            @foreach($this->states as $key => $label)
+            @foreach($states as $key => $label)
                 <option value="{{ $key }}">{{ $label }}</option>
             @endforeach
         </select>

--- a/routes/web.php
+++ b/routes/web.php
@@ -40,8 +40,8 @@ Route::middleware(['auth'])->group(function () {
     Route::get('/operador/solicitudes/{solicitud}/evaluate', [OperadorSolicitudController::class, 'evaluate'])
         ->name('operador.solicitudes.evaluate');
 
-    Route::view('/archivo-central', 'archivo-central')
-        ->name('archivo-central');
+    Route::get('/archivo-central', \App\Http\Controllers\ArchivoCentralController::class)
+        ->name('archivo.central');
 
     Volt::route('settings/profile', 'settings.profile')->name('settings.profile');
     Volt::route('settings/password', 'settings.password')->name('settings.password');

--- a/tests/Feature/ArchivoCentralTest.php
+++ b/tests/Feature/ArchivoCentralTest.php
@@ -4,6 +4,8 @@ namespace Tests\Feature;
 
 use App\Livewire\ArchivoCentral;
 use App\Models\Expediente;
+use App\Models\Facultad;
+use App\Models\Tramite;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Livewire\Livewire;
 use Tests\TestCase;
@@ -61,5 +63,39 @@ class ArchivoCentralTest extends TestCase
         $first = $component->viewData('expedientes')->first();
 
         $this->assertEquals($expediente->id, $first->codigo);
+    }
+
+    public function test_filter_by_faculty(): void
+    {
+        $arquitectura = Facultad::factory()->create(['nombre' => 'Arquitectura']);
+        $otra = Facultad::factory()->create(['nombre' => 'Ingeniería Civil']);
+
+        Expediente::factory()->create(['facultad_id' => $arquitectura->id]);
+        Expediente::factory()->create(['facultad_id' => $otra->id]);
+
+        $component = Livewire::test(ArchivoCentral::class)
+            ->set('faculty', 'Arquitectura');
+
+        $data = $component->viewData('expedientes');
+
+        $this->assertCount(1, $data);
+        $this->assertEquals('Arquitectura', $data->first()->facultad->nombre);
+    }
+
+    public function test_filter_by_type(): void
+    {
+        $tipoA = Tramite::factory()->create(['nombre' => 'CARNÉ UNIVERSITARIO']);
+        $tipoB = Tramite::factory()->create(['nombre' => 'SEMIBECAS Y BECAS – CEPRE']);
+
+        Expediente::factory()->create(['tipo_tramite_id' => $tipoA->id]);
+        Expediente::factory()->create(['tipo_tramite_id' => $tipoB->id]);
+
+        $component = Livewire::test(ArchivoCentral::class)
+            ->set('type', 'CARNÉ UNIVERSITARIO');
+
+        $data = $component->viewData('expedientes');
+
+        $this->assertCount(1, $data);
+        $this->assertEquals('CARNÉ UNIVERSITARIO', $data->first()->tramite->nombre);
     }
 }


### PR DESCRIPTION
## Summary
- route `/archivo-central` now handled by controller
- add lists of Facultades and Types to the ArchivoCentral component
- filter results by faculty/type names
- expose filter lists to the Blade view
- update sidebar to new route name
- add feature tests for faculty and type filters

## Testing
- `php artisan test --testsuite=Feature`

------
https://chatgpt.com/codex/tasks/task_e_687401bb648083279947cf3ddf7dd500