### PR TITLE
Implement expediente delivery audit logging

### DIFF
--- a/app/Http/Controllers/AuditEntregaController.php
+++ b/app/Http/Controllers/AuditEntregaController.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\AuditEntrega;
+use Illuminate\Http\Request;
+
+class AuditEntregaController extends Controller
+{
+    public function index(Request $request)
+    {
+        $query = AuditEntrega::with(['expediente', 'solicitante', 'operador'])
+            ->orderByDesc('delivered_at');
+
+        if ($request->filled('from')) {
+            $query->whereDate('delivered_at', '>=', $request->input('from'));
+        }
+
+        if ($request->filled('to')) {
+            $query->whereDate('delivered_at', '<=', $request->input('to'));
+        }
+
+        if ($request->filled('expediente')) {
+            $query->whereHas('expediente', function ($q) use ($request) {
+                $q->where('codigo', $request->input('expediente'));
+            });
+        }
+
+        if ($request->filled('operador')) {
+            $query->whereHas('operador', function ($q) use ($request) {
+                $q->where('name', 'like', '%'.$request->input('operador').'%');
+            });
+        }
+
+        if ($request->filled('solicitante')) {
+            $query->whereHas('solicitante', function ($q) use ($request) {
+                $q->where('name', 'like', '%'.$request->input('solicitante').'%');
+            });
+        }
+
+        $audits = $query->paginate();
+
+        return view('auditoria.entregas.index', compact('audits'));
+    }
+}

--- a/app/Http/Controllers/ExpedienteEntregadoController.php
+++ b/app/Http/Controllers/ExpedienteEntregadoController.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\StoreExpedienteEntregadoRequest;
+use App\Models\Expediente;
+use App\Models\ExpedienteEntregado;
+use App\Models\AuditEntrega;
+use App\Models\SolicitudExpediente;
+use App\Notifications\ExpedienteEntregadoNotification;
+use Illuminate\Support\Facades\Storage;
+
+class ExpedienteEntregadoController extends Controller
+{
+    public function create(int $id)
+    {
+        $solicitud = SolicitudExpediente::findOrFail($id);
+
+        return view('operador.entregados.create', compact('solicitud'));
+    }
+
+    public function store(StoreExpedienteEntregadoRequest $request, int $id)
+    {
+        $solicitud = SolicitudExpediente::findOrFail($id);
+        $expediente = Expediente::where('codigo', $solicitud->codigo_expediente)->firstOrFail();
+
+        foreach ($request->file('files') as $file) {
+            $path = $file->store('entregas');
+
+            $entrega = ExpedienteEntregado::create([
+                'expediente_id' => $expediente->id,
+                'solicitud_id' => $solicitud->id,
+                'ruta' => $path,
+                'user_id' => $request->user()->id,
+                'visible_para_usuario' => false,
+            ]);
+
+            AuditEntrega::create([
+                'expediente_id' => $expediente->id,
+                'solicitante_id' => $entrega->user_id,
+                'operador_id' => $request->user()->id,
+                'delivered_at' => now(),
+            ]);
+        }
+
+        $solicitud->update(['status' => SolicitudExpediente::APPROVED]);
+
+        return redirect()->route('operador.solicitudes.show', $solicitud)
+            ->with('success', __('Expediente entregado correctamente.'));
+    }
+
+    public function notify(ExpedienteEntregado $entrega)
+    {
+        $entrega->update(['visible_para_usuario' => true]);
+
+        $entrega->user->notify(new ExpedienteEntregadoNotification($entrega));
+
+        return back()->with('success', __('Usuario notificado correctamente.'));
+    }
+}

--- a/app/Http/Middleware/RoleMiddleware.php
+++ b/app/Http/Middleware/RoleMiddleware.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+
+class RoleMiddleware
+{
+    public function handle(Request $request, Closure $next, string $role)
+    {
+        $user = $request->user();
+
+        if (! $user || $user->role?->name !== $role) {
+            abort(403);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Http/Requests/StoreExpedienteEntregadoRequest.php
+++ b/app/Http/Requests/StoreExpedienteEntregadoRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreExpedienteEntregadoRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'files' => ['required', 'array'],
+            'files.*' => 'required|file|mimes:pdf,docx|max:10240',
+        ];
+    }
+}

--- a/app/Models/AuditEntrega.php
+++ b/app/Models/AuditEntrega.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class AuditEntrega extends Model
+{
+    use HasFactory;
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'expediente_id',
+        'solicitante_id',
+        'operador_id',
+        'delivered_at',
+    ];
+
+    protected $casts = [
+        'delivered_at' => 'datetime',
+    ];
+
+    public function expediente(): BelongsTo
+    {
+        return $this->belongsTo(Expediente::class);
+    }
+
+    public function solicitante(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'solicitante_id');
+    }
+
+    public function operador(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'operador_id');
+    }
+}

--- a/app/Models/ExpedienteEntregado.php
+++ b/app/Models/ExpedienteEntregado.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class ExpedienteEntregado extends Model
+{
+    use HasFactory;
+
+    protected $table = 'expediente_entregado';
+
+    protected $fillable = [
+        'expediente_id',
+        'solicitud_id',
+        'ruta',
+        'user_id',
+        'visible_para_usuario',
+    ];
+
+    protected $casts = [
+        'visible_para_usuario' => 'boolean',
+    ];
+
+    public function expediente()
+    {
+        return $this->belongsTo(Expediente::class);
+    }
+
+    public function solicitud()
+    {
+        return $this->belongsTo(SolicitudExpediente::class, 'solicitud_id');
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Role extends Model
+{
+    public $timestamps = false;
+
+    protected $fillable = ['name'];
+
+    public function users(): HasMany
+    {
+        return $this->hasMany(User::class);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Str;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class User extends Authenticatable
 {
@@ -48,6 +49,11 @@ class User extends Authenticatable
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
         ];
+    }
+
+    public function role(): BelongsTo
+    {
+        return $this->belongsTo(Role::class);
     }
 
     /**

--- a/app/Notifications/ExpedienteEntregadoNotification.php
+++ b/app/Notifications/ExpedienteEntregadoNotification.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\ExpedienteEntregado;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+use Illuminate\Support\Facades\Storage;
+
+class ExpedienteEntregadoNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(public ExpedienteEntregado $entrega)
+    {
+    }
+
+    public function via($notifiable): array
+    {
+        return ['mail', 'database'];
+    }
+
+    public function toMail($notifiable): MailMessage
+    {
+        return (new MailMessage())
+            ->subject(__('Copia de expediente disponible'))
+            ->line(__('Se ha cargado una copia de su expediente solicitado.'))
+            ->action(__('Descargar'), url(Storage::url($this->entrega->ruta)));
+    }
+
+    public function toArray($notifiable): array
+    {
+        return [
+            'entrega_id' => $this->entrega->id,
+            'ruta' => $this->entrega->ruta,
+        ];
+    }
+}

--- a/app/Policies/AuditEntregaPolicy.php
+++ b/app/Policies/AuditEntregaPolicy.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\AuditEntrega;
+use App\Models\User;
+
+class AuditEntregaPolicy
+{
+    public function viewAny(User $user): bool
+    {
+        return $user->role?->name === 'product_owner';
+    }
+
+    public function view(User $user, AuditEntrega $audit): bool
+    {
+        return $user->role?->name === 'product_owner';
+    }
+
+    public function update(User $user, AuditEntrega $audit): bool
+    {
+        return false;
+    }
+
+    public function delete(User $user, AuditEntrega $audit): bool
+    {
+        return false;
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
+use App\Models\AuditEntrega;
+use App\Policies\AuditEntregaPolicy;
+
+class AuthServiceProvider extends ServiceProvider
+{
+    /**
+     * Register services.
+     */
+    public function register(): void
+    {
+        //
+    }
+
+    /**
+     * Bootstrap services.
+     */
+    protected $policies = [
+        AuditEntrega::class => AuditEntregaPolicy::class,
+    ];
+
+    public function boot(): void
+    {
+        $this->registerPolicies();
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -11,7 +11,9 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware) {
-        //
+        $middleware->alias([
+            'role' => \App\Http\Middleware\RoleMiddleware::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {
         //

--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -2,5 +2,6 @@
 
 return [
     App\Providers\AppServiceProvider::class,
+    App\Providers\AuthServiceProvider::class,
     App\Providers\VoltServiceProvider::class,
 ];

--- a/database/factories/AuditEntregaFactory.php
+++ b/database/factories/AuditEntregaFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use App\Models\Expediente;
+use App\Models\User;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\AuditEntrega>
+ */
+class AuditEntregaFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'expediente_id' => Expediente::factory(),
+            'solicitante_id' => User::factory(),
+            'operador_id' => User::factory(),
+            'delivered_at' => now(),
+        ];
+    }
+}

--- a/database/factories/ExpedienteEntregadoFactory.php
+++ b/database/factories/ExpedienteEntregadoFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Expediente;
+use App\Models\ExpedienteEntregado;
+use App\Models\SolicitudExpediente;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ExpedienteEntregadoFactory extends Factory
+{
+    protected $model = ExpedienteEntregado::class;
+
+    public function definition(): array
+    {
+        return [
+            'expediente_id' => Expediente::factory(),
+            'solicitud_id' => SolicitudExpediente::factory(),
+            'ruta' => 'entregas/'.$this->faker->word.'.pdf',
+            'user_id' => User::factory(),
+            'visible_para_usuario' => false,
+        ];
+    }
+}

--- a/database/migrations/2025_07_13_192620_create_expediente_entregado_table.php
+++ b/database/migrations/2025_07_13_192620_create_expediente_entregado_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('expediente_entregado', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('expediente_id')->constrained('expedientes');
+            $table->foreignId('solicitud_id')->constrained('solicitud_expedientes');
+            $table->foreignId('user_id')->constrained('users');
+            $table->string('ruta');
+            $table->boolean('visible_para_usuario')->default(false);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('expediente_entregado');
+    }
+};

--- a/database/migrations/2025_07_13_194124_create_audit_entregas_table.php
+++ b/database/migrations/2025_07_13_194124_create_audit_entregas_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('audit_entregas', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('expediente_id')->constrained('expedientes');
+            $table->foreignId('solicitante_id')->constrained('users');
+            $table->foreignId('operador_id')->constrained('users');
+            $table->timestamp('delivered_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('audit_entregas');
+    }
+};

--- a/resources/views/auditoria/entregas/index.blade.php
+++ b/resources/views/auditoria/entregas/index.blade.php
@@ -1,0 +1,40 @@
+<x-layouts.app :title="__('Auditor\xC3\xADa de Entregas')">
+    <div class="container mx-auto p-6">
+        <h1 class="text-xl font-semibold mb-4">{{ __('Auditor\xC3\xADa de Entregas') }}</h1>
+        <form method="GET" class="grid grid-cols-4 gap-4 mb-4">
+            <input type="date" name="from" value="{{ request('from') }}" class="border p-2 rounded" />
+            <input type="date" name="to" value="{{ request('to') }}" class="border p-2 rounded" />
+            <input type="text" name="expediente" placeholder="{{ __('Expediente') }}" value="{{ request('expediente') }}" class="border p-2 rounded" />
+            <input type="text" name="solicitante" placeholder="{{ __('Solicitante') }}" value="{{ request('solicitante') }}" class="border p-2 rounded" />
+            <input type="text" name="operador" placeholder="{{ __('Operador') }}" value="{{ request('operador') }}" class="border p-2 rounded" />
+            <button type="submit" class="bg-indigo-600 text-white px-4 py-2 rounded">{{ __('Filtrar') }}</button>
+        </form>
+        <div class="overflow-x-auto">
+            <table class="min-w-full divide-y divide-gray-200 text-sm">
+                <thead>
+                <tr>
+                    <th class="p-2">{{ __('Fecha') }}</th>
+                    <th class="p-2">{{ __('Expediente') }}</th>
+                    <th class="p-2">{{ __('Solicitante') }}</th>
+                    <th class="p-2">{{ __('Operador') }}</th>
+                </tr>
+                </thead>
+                <tbody class="divide-y divide-gray-200">
+                @forelse($audits as $audit)
+                    <tr>
+                        <td class="p-2">{{ $audit->delivered_at->format('Y-m-d H:i') }}</td>
+                        <td class="p-2">{{ $audit->expediente->codigo }}</td>
+                        <td class="p-2">{{ $audit->solicitante->name ?? '' }}</td>
+                        <td class="p-2">{{ $audit->operador->name }}</td>
+                    </tr>
+                @empty
+                    <tr>
+                        <td colspan="4" class="p-4 text-center">{{ __('SIN RESULTADOS') }}</td>
+                    </tr>
+                @endforelse
+                </tbody>
+            </table>
+        </div>
+        {{ $audits->withQueryString()->links() }}
+    </div>
+</x-layouts.app>

--- a/resources/views/operador/entregados/create.blade.php
+++ b/resources/views/operador/entregados/create.blade.php
@@ -1,0 +1,14 @@
+<x-layouts.app :title="__('Entregar Expediente')">
+    <div class="container mx-auto max-w-xl p-6">
+        <h1 class="text-xl font-semibold mb-4">{{ __('Subir Copia de Expediente') }}</h1>
+        <form method="POST" action="{{ route('operador.solicitudes.entregar.store', $solicitud->id) }}" enctype="multipart/form-data" class="grid gap-4">
+            @csrf
+            <x-form.upload name="files[]" label="{{ __('Seleccionar archivos') }}" :errors="$errors->get('files.*')" />
+            <div class="flex justify-end">
+                <button type="submit" class="bg-indigo-600 text-white px-4 py-2 rounded hover:bg-indigo-700">
+                    {{ __('Entregar') }}
+                </button>
+            </div>
+        </form>
+    </div>
+</x-layouts.app>

--- a/routes/web.php
+++ b/routes/web.php
@@ -40,12 +40,24 @@ Route::middleware(['auth'])->group(function () {
     Route::get('/operador/solicitudes/{solicitud}/evaluate', [OperadorSolicitudController::class, 'evaluate'])
         ->name('operador.solicitudes.evaluate');
 
+    Route::get('/operador/solicitudes/{id}/entregar', [\App\Http\Controllers\ExpedienteEntregadoController::class, 'create'])
+        ->name('operador.solicitudes.entregar.create');
+    Route::post('/operador/solicitudes/{id}/entregar', [\App\Http\Controllers\ExpedienteEntregadoController::class, 'store'])
+        ->name('operador.solicitudes.entregar.store');
+    Route::post('/operador/entregados/{entrega}/notificar', [\App\Http\Controllers\ExpedienteEntregadoController::class, 'notify'])
+        ->name('operador.entregados.notificar');
+
     Route::get('/archivo-central', \App\Http\Controllers\ArchivoCentralController::class)
         ->name('archivo.central');
 
     Volt::route('settings/profile', 'settings.profile')->name('settings.profile');
     Volt::route('settings/password', 'settings.password')->name('settings.password');
     Volt::route('settings/appearance', 'settings.appearance')->name('settings.appearance');
+});
+
+Route::middleware(['auth', 'role:product_owner'])->group(function () {
+    Route::get('/auditoria/entregas', [\App\Http\Controllers\AuditEntregaController::class, 'index'])
+        ->name('auditoria.entregas.index');
 });
 
 require __DIR__.'/auth.php';

--- a/tests/Browser/AuditEntregaViewTest.php
+++ b/tests/Browser/AuditEntregaViewTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\Browser;
+
+use App\Models\AuditEntrega;
+use App\Models\Role;
+use App\Models\User;
+use Laravel\Dusk\Browser;
+use Tests\DuskTestCase;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+
+class AuditEntregaViewTest extends DuskTestCase
+{
+    use DatabaseMigrations;
+
+    public function test_audit_page_loads_without_edit_buttons(): void
+    {
+        $role = Role::create(['name' => 'product_owner']);
+        $owner = User::factory()->create(['role_id' => $role->id]);
+
+        AuditEntrega::factory()->create();
+
+        $this->browse(function (Browser $browser) use ($owner) {
+            $browser->loginAs($owner)
+                ->visit(route('auditoria.entregas.index'))
+                ->assertDontSee('Editar')
+                ->assertDontSee('Eliminar');
+        });
+    }
+}

--- a/tests/Feature/AuditEntregaTest.php
+++ b/tests/Feature/AuditEntregaTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\AuditEntrega;
+use App\Models\Expediente;
+use App\Models\SolicitudExpediente;
+use App\Models\User;
+use App\Models\Role;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class AuditEntregaTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_store_creates_audit_record(): void
+    {
+        Storage::fake('local');
+
+        $operator = User::factory()->create(['role_id' => 4]);
+        $solicitud = SolicitudExpediente::factory()->create();
+        $expediente = Expediente::factory()->create(['codigo' => $solicitud->codigo_expediente]);
+
+        $response = $this->actingAs($operator)->post(route('operador.solicitudes.entregar.store', $solicitud->id), [
+            'files' => [UploadedFile::fake()->create('file.pdf', 100, 'application/pdf')],
+        ]);
+
+        $response->assertRedirect();
+        $this->assertDatabaseHas('audit_entregas', [
+            'expediente_id' => $expediente->id,
+            'operador_id' => $operator->id,
+        ]);
+    }
+
+    public function test_only_product_owner_can_view_audit_page(): void
+    {
+        $role = Role::create(['name' => 'product_owner']);
+        $owner = User::factory()->create(['role_id' => $role->id]);
+        $user = User::factory()->create();
+
+        $this->actingAs($owner)->get(route('auditoria.entregas.index'))
+            ->assertStatus(200);
+
+        $this->actingAs($user)->get(route('auditoria.entregas.index'))
+            ->assertStatus(403);
+    }
+}

--- a/tests/Feature/ExpedienteEntregadoTest.php
+++ b/tests/Feature/ExpedienteEntregadoTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Expediente;
+use App\Models\SolicitudExpediente;
+use App\Models\User;
+use App\Models\ExpedienteEntregado;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class ExpedienteEntregadoTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_store_creates_entregas(): void
+    {
+        Storage::fake('local');
+
+        $operator = User::factory()->create(['role_id' => 4]);
+        $solicitud = SolicitudExpediente::factory()->create();
+        $expediente = Expediente::factory()->create(['codigo' => $solicitud->codigo_expediente]);
+
+        $files = [
+            UploadedFile::fake()->create('a.pdf', 100, 'application/pdf'),
+            UploadedFile::fake()->create('b.docx', 100, 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'),
+        ];
+
+        $response = $this->actingAs($operator)->post(route('operador.solicitudes.entregar.store', $solicitud->id), [
+            'files' => $files,
+        ]);
+
+        $response->assertRedirect();
+        $this->assertDatabaseCount('expediente_entregado', 2);
+        Storage::disk('local')->assertExists('entregas/'.$files[0]->hashName());
+        $this->assertEquals(SolicitudExpediente::APPROVED, $solicitud->refresh()->status);
+    }
+
+    public function test_notify_marks_visible_and_sends_notification(): void
+    {
+        Notification::fake();
+        $operator = User::factory()->create(['role_id' => 4]);
+        $user = User::factory()->create();
+        $entrega = ExpedienteEntregado::factory()->create(['user_id' => $user->id]);
+
+        $this->actingAs($operator)->post(route('operador.entregados.notificar', $entrega));
+
+        $this->assertTrue($entrega->refresh()->visible_para_usuario);
+        Notification::assertSentTo($user, \App\Notifications\ExpedienteEntregadoNotification::class);
+    }
+}


### PR DESCRIPTION
## Summary
- track expediente deliveries with `AuditEntrega` model and migration
- create role middleware and add product owner audit route
- log each delivery in `AuditEntregaController@store`
- list audit entries in new controller and view
- protect audit entries with policy and role-based access
- include feature and browser tests

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_687405998a348327a02b180fa5c8f6af