### PR TITLE
Add product owner role and restrict audit route

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -2,10 +2,10 @@
 
 namespace Database\Seeders;
 
-use App\Models\User;
 use Database\Seeders\DependenciaSeeder;
 use Database\Seeders\TramiteSeeder;
 use Database\Seeders\FacultadSeeder;
+use Database\Seeders\RoleSeeder;
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
@@ -14,13 +14,14 @@ class DatabaseSeeder extends Seeder
     /**
      * Seed the application's database.
      */
-    public function run()
-{
-    $this->call([
-        UserSeeder::class, // ← Añade esta línea
-        DependenciaSeeder::class,
-        TramiteSeeder::class,
-        FacultadSeeder::class,
-    ]);
-}
+    public function run(): void
+    {
+        $this->call([
+            RoleSeeder::class,
+            UserSeeder::class,
+            DependenciaSeeder::class,
+            TramiteSeeder::class,
+            FacultadSeeder::class,
+        ]);
+    }
 }

--- a/database/seeders/RoleSeeder.php
+++ b/database/seeders/RoleSeeder.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class RoleSeeder extends Seeder
+{
+    public function run(): void
+    {
+        DB::table('roles')->upsert([
+            ['id' => 1, 'name' => 'usuario'],
+            ['id' => 4, 'name' => 'operador'],
+            ['id' => 5, 'name' => 'product_owner'],
+        ], ['id'], ['name']);
+    }
+}

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -62,6 +62,17 @@ class UserSeeder extends Seeder
                 'email_verified_at' => now(),
                 'created_at' => now(),
                 'updated_at' => now()
+            ],
+            [
+                'name' => 'Product',
+                'last_name' => 'Owner',
+                'email' => 'owner@example.com',
+                'dni' => '52345678',
+                'role_id' => 5,
+                'password' => Hash::make('password123'),
+                'email_verified_at' => now(),
+                'created_at' => now(),
+                'updated_at' => now()
             ]
         ];
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -67,8 +67,6 @@ Route::middleware(['auth', 'role:4', 'session.timeout'])->prefix('operador')->gr
     Route::post('/entregas/{entrega}/notificacion', [NotificacionController::class, 'store'])
         ->name('operador.notificacion.store');
 
-    Route::get('/auditoria', [AuditEntregaController::class, 'index'])
-        ->name('operador.auditoria');
 });
 
 Route::middleware(['auth', 'role:4', 'session.timeout'])->get('/archivo-central', function () {
@@ -78,6 +76,8 @@ Route::middleware(['auth', 'role:4', 'session.timeout'])->get('/archivo-central'
 Route::middleware(['auth', 'role:product_owner'])->group(function () {
     Route::get('/auditoria/entregas', [\App\Http\Controllers\AuditEntregaController::class, 'index'])
         ->name('auditoria.entregas.index');
+    Route::get('/operador/auditoria', [\App\Http\Controllers\AuditEntregaController::class, 'index'])
+        ->name('operador.auditoria');
 });
 
 Route::post('/notificaciones/{notificacion}/confirmar', [NotificacionController::class, 'confirm'])

--- a/tests/Feature/AuditEntregaAccessTest.php
+++ b/tests/Feature/AuditEntregaAccessTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\Role;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AuditEntregaAccessTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_product_owner_can_access(): void
+    {
+        Role::create(['id' => 5, 'name' => 'product_owner']);
+        $owner = User::factory()->create(['role_id' => 5]);
+
+        $this->actingAs($owner)
+            ->get('/operador/auditoria')
+            ->assertStatus(200);
+    }
+
+    public function test_operator_cannot_access(): void
+    {
+        $operator = User::factory()->create(['role_id' => 4]);
+
+        $this->actingAs($operator)
+            ->get('/operador/auditoria')
+            ->assertStatus(403);
+    }
+}


### PR DESCRIPTION
## Summary
- seed roles including product owner
- create default product owner user
- call `RoleSeeder` in `DatabaseSeeder`
- move auditoria route to product owner middleware group
- add feature test for audit access

## Testing
- `php artisan test --testsuite=Feature`

------
https://chatgpt.com/codex/tasks/task_e_68741ec086808327b1820af509b9755c