### PR TITLE
Add status-based views and pagination

### DIFF
--- a/app/Livewire/CentralFileFilter.php
+++ b/app/Livewire/CentralFileFilter.php
@@ -3,40 +3,48 @@
 namespace App\Livewire;
 
 use Livewire\Component;
+use Livewire\WithPagination;
 use App\Models\Expedientes;
 use App\Models\Facultad;
 
 class CentralFileFilter extends Component
 {
+    use WithPagination;
+
     public $dni;
     public $year;
     public $month_id;
     public $faculty_id;
     public $tramite_type_id;
-    public $status_id;
+    public $statusId;
     public $facultades;
     public $months;
     public $tramiteTypes;
-    public $statuses;
     public $years;
+    public $perPage = 10;
 
-    public function mount()
+    public function mount($statusId = null)
     {
+        $this->statusId = $statusId;
         $this->facultades = Facultad::orderBy('nombre')->get();
         $this->months = \App\Models\Month::all();
         $this->tramiteTypes = \App\Models\TramiteType::all();
-        $this->statuses = \App\Models\Status::all();
         $this->years = Expedientes::select('year')->distinct()->orderBy('year')->pluck('year');
     }
 
     public function limpiarFiltros()
     {
-        $this->reset(['dni', 'year', 'month_id', 'faculty_id', 'tramite_type_id', 'status_id']);
+        $this->reset(['dni', 'year', 'month_id', 'faculty_id', 'tramite_type_id']);
     }
 
     public function applyFilters()
     {
         // Method intentionally left blank; Livewire will re-render on invocation
+    }
+
+    public function updated($property)
+    {
+        $this->resetPage();
     }
 
     public function render()
@@ -64,18 +72,17 @@ class CentralFileFilter extends Component
             $query->where('tramite_type_id', $this->tramite_type_id);
         }
 
-        if ($this->status_id) {
-            $query->where('status_id', $this->status_id);
+        if ($this->statusId) {
+            $query->where('status_id', $this->statusId);
         }
 
-        $files = $query->get();
+        $files = $query->paginate($this->perPage);
 
         return view('livewire.central-file-filter', [
             'files' => $files,
             'facultades' => $this->facultades,
             'months' => $this->months,
             'tramiteTypes' => $this->tramiteTypes,
-            'statuses' => $this->statuses,
             'years' => $this->years,
         ]);
     }

--- a/resources/views/components/layouts/app/sidebar.blade.php
+++ b/resources/views/components/layouts/app/sidebar.blade.php
@@ -16,6 +16,9 @@
                 <flux:navlist.group class="grid">
                     <flux:navlist.item icon="home" :href="route('dashboard')" :current="request()->routeIs('dashboard')" wire:navigate>{{ __('Dashboard') }}</flux:navlist.item>
                     <flux:navlist.item icon="document-magnifying-glass" :href="route('archivo.central')" :current="request()->routeIs('archivo.central')" wire:navigate>{{ __('Archivo Central') }}</flux:navlist.item>
+                    <flux:navlist.item icon="clock" :href="route('tramite.pendiente')" :current="request()->routeIs('tramite.pendiente')" wire:navigate>{{ __('Trámite Pendiente') }}</flux:navlist.item>
+                    <flux:navlist.item icon="document-arrow-right" :href="route('tramite.proceso')" :current="request()->routeIs('tramite.proceso')" wire:navigate>{{ __('Trámite en Proceso') }}</flux:navlist.item>
+                    <flux:navlist.item icon="document-check" :href="route('tramite.finalizado')" :current="request()->routeIs('tramite.finalizado')" wire:navigate>{{ __('Trámite Finalizado') }}</flux:navlist.item>
                     <flux:navlist.item icon="document-plus" :href="route('carga.documentos')" :current="request()->routeIs('carga.documentos')" wire:navigate>{{ __('Cargar Documentos') }}</flux:navlist.item>
                     <flux:navlist.item icon="document-text" :href="route('registro.expediente')" :current="request()->routeIs('registro.expediente')" wire:navigate>{{ __('Registro Expediente') }}</flux:navlist.item>
                     <flux:navlist.item icon="document-duplicate" :href="route('solicitudes.pendientes')" :current="request()->routeIs('solicitudes.pendientes')" wire:navigate>{{ __('Solicitudes Pendientes') }}</flux:navlist.item>

--- a/resources/views/livewire/central-file-filter.blade.php
+++ b/resources/views/livewire/central-file-filter.blade.php
@@ -38,12 +38,6 @@
         @endforeach
     </flux:select>
 
-    <flux:select wire:model.defer="status_id" placeholder="Estado" label="Estado">
-        <flux:select.option value="">Todos</flux:select.option>
-        @foreach($statuses as $status)
-            <flux:select.option value="{{ $status->id }}">{{ $status->name }}</flux:select.option>
-        @endforeach
-    </flux:select>
 
     <div class="flex justify-end gap-2">
         <flux:button wire:click="applyFilters" variant="primary" color="green">
@@ -95,6 +89,10 @@
         @endforelse
     </tbody>
 </table>
+
+    <div class="mt-4">
+        {{ $files->links() }}
+    </div>
 
 
 </div>

--- a/resources/views/tramite_en_proceso.blade.php
+++ b/resources/views/tramite_en_proceso.blade.php
@@ -1,0 +1,3 @@
+<x-layouts.app :title="__('Trámite en Proceso')">
+    @livewire('central-file-filter', ['statusId' => 2])
+</x-layouts.app>

--- a/resources/views/tramite_finalizado.blade.php
+++ b/resources/views/tramite_finalizado.blade.php
@@ -1,0 +1,3 @@
+<x-layouts.app :title="__('Trámite Finalizado')">
+    @livewire('central-file-filter', ['statusId' => 3])
+</x-layouts.app>

--- a/resources/views/tramite_pendiente.blade.php
+++ b/resources/views/tramite_pendiente.blade.php
@@ -1,0 +1,3 @@
+<x-layouts.app :title="__('Trámite Pendiente')">
+    @livewire('central-file-filter', ['statusId' => 1])
+</x-layouts.app>

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,6 +17,18 @@ Route::get('archivo_central', CentralFileFilter::class)
     ->middleware(['auth', 'verified'])
     ->name('archivo.central');
 
+Route::view('tramite_pendiente', 'tramite_pendiente')
+    ->middleware(['auth', 'verified'])
+    ->name('tramite.pendiente');
+
+Route::view('tramite_en_proceso', 'tramite_en_proceso')
+    ->middleware(['auth', 'verified'])
+    ->name('tramite.proceso');
+
+Route::view('tramite_finalizado', 'tramite_finalizado')
+    ->middleware(['auth', 'verified'])
+    ->name('tramite.finalizado');
+
 Route::view('carga_documentos', 'carga_documentos')
     ->middleware(['auth', 'verified'])
     ->name('carga.documentos');


### PR DESCRIPTION
## Summary
- remove estado filter from central file view
- add pagination to expediente listings
- add routes and sidebar links for pending, in-process, and finalized views
- create new views for each status

## Testing
- `composer test` *(fails: could not run due to missing dependencies and DB issues)*

------
https://chatgpt.com/codex/tasks/task_e_687d68d132448327bfa25ccb7f8ff8d0