### PR TITLE
Fix migrations and views alignment

### DIFF
--- a/app/Livewire/CanalizarEnvio.php
+++ b/app/Livewire/CanalizarEnvio.php
@@ -6,6 +6,7 @@ use Livewire\Component;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
+use App\Models\Status;
 
 class CanalizarEnvio extends Component
 {
@@ -27,8 +28,9 @@ class CanalizarEnvio extends Component
 
     public function cargarExpedientes()
     {
+        $enviado = Status::where('name', 'Enviado')->value('id');
         $this->expedientes = DB::table('expedientes')
-            ->where('status_id', 'Enviado')
+            ->where('status_id', $enviado)
             ->where('medio_envio', 'Otro medio')
             ->orderByDesc('fecha_envio')
             ->get();
@@ -78,9 +80,10 @@ class CanalizarEnvio extends Component
             $response = Http::withHeaders($headers)->post($this->endpoint, $payload);
 
             if ($response->successful()) {
+                $canalizado = Status::where('name', 'Canalizado')->value('id');
                 DB::table('expedientes')
                     ->where('id', $this->expedienteSeleccionado->id)
-                    ->update(['estado' => 'Canalizado']);
+                    ->update(['status_id' => $canalizado]);
 
                 return redirect()->route('canalizarEnvio')
                     ->with('success', 'Envío realizado correctamente al servicio externo.');

--- a/app/Livewire/CentralFileFilter.php
+++ b/app/Livewire/CentralFileFilter.php
@@ -4,7 +4,7 @@ namespace App\Livewire;
 
 use Livewire\Component;
 use Livewire\WithPagination;
-use App\Models\Expedientes;
+use App\Models\Expediente;
 use App\Models\Facultad;
 
 class CentralFileFilter extends Component
@@ -29,7 +29,7 @@ class CentralFileFilter extends Component
         $this->facultades = Facultad::orderBy('nombre')->get();
         $this->months = \App\Models\Month::all();
         $this->tramiteTypes = \App\Models\TramiteType::all();
-        $this->years = Expedientes::select('year')->distinct()->orderBy('year')->pluck('year');
+        $this->years = Expediente::select('year')->distinct()->orderBy('year')->pluck('year');
     }
 
     public function limpiarFiltros()
@@ -50,7 +50,7 @@ class CentralFileFilter extends Component
     public function render()
     {
         // Carga la relación facultad
-        $query = Expedientes::with('facultad');
+        $query = Expediente::with('facultad');
 
         if ($this->dni) {
             $query->where('dni', $this->dni);

--- a/app/Livewire/PanelSeguimiento.php
+++ b/app/Livewire/PanelSeguimiento.php
@@ -22,13 +22,17 @@ class PanelSeguimiento extends Component
     {
         // Conteo general sin filtro (para mantener el resumen completo)
         $this->resumen = DB::table('expedientes')
-            ->select('status_id', DB::raw('count(*) as total'))
-            ->groupBy('status_id')
-            ->pluck('total', 'status_id')
+            ->join('statuses', 'expedientes.status_id', '=', 'statuses.id')
+            ->select('statuses.name as estado', DB::raw('count(*) as total'))
+            ->groupBy('statuses.name')
+            ->pluck('total', 'estado')
             ->toArray();
 
         // Filtro por fechas (si están definidos)
-        $query = DB::table('expedientes')->orderByDesc('updated_at');
+        $query = DB::table('expedientes')
+            ->leftJoin('statuses', 'expedientes.status_id', '=', 'statuses.id')
+            ->select('expedientes.*', 'statuses.name as estado')
+            ->orderByDesc('expedientes.updated_at');
 
         if ($this->fechaInicio) {
             $query->whereDate('updated_at', '>=', $this->fechaInicio);

--- a/app/Livewire/RegistroEnvioAutomatico.php
+++ b/app/Livewire/RegistroEnvioAutomatico.php
@@ -4,6 +4,7 @@ namespace App\Livewire;
 
 use Livewire\Component;
 use Illuminate\Support\Facades\DB;
+use App\Models\Status;
 
 class RegistroEnvioAutomatico extends Component
 {
@@ -32,7 +33,8 @@ class RegistroEnvioAutomatico extends Component
 
     private function actualizarTotalPaginas()
     {
-        $totalExpedientes = DB::table('expedientes')->where('status_id', 'Enviado')->count();
+        $enviado = Status::where('name', 'Enviado')->value('id');
+        $totalExpedientes = DB::table('expedientes')->where('status_id', $enviado)->count();
         $this->totalPaginas = (int) ceil($totalExpedientes / $this->porPagina);
     }
 
@@ -40,8 +42,9 @@ class RegistroEnvioAutomatico extends Component
     {
         $this->actualizarTotalPaginas();
 
+        $enviado = Status::where('name', 'Enviado')->value('id');
         $expedientes = DB::table('expedientes')
-            ->where('status_id', 'Enviado')
+            ->where('status_id', $enviado)
             ->orderByDesc('fecha_envio')
             ->offset(($this->paginaActual - 1) * $this->porPagina)
             ->limit($this->porPagina)

--- a/app/Livewire/RegistroObservaciones.php
+++ b/app/Livewire/RegistroObservaciones.php
@@ -4,6 +4,7 @@ namespace App\Livewire;
 
 use Livewire\Component;
 use App\Models\Expediente;
+use App\Models\Status;
 
 class RegistroObservaciones extends Component
 {
@@ -23,7 +24,7 @@ class RegistroObservaciones extends Component
                 $this->expedienteId = $expediente->id;
                 $this->expedienteCodigo = $expediente->codigo;
                 $this->solicitante = $expediente->solicitante;
-                $this->estadoExpediente = $expediente->status_id;
+                $this->estadoExpediente = optional($expediente->status)->name;
             }
         }
     }
@@ -39,7 +40,8 @@ class RegistroObservaciones extends Component
             $expediente = Expediente::find($this->expedienteId);
 
             if ($expediente) {
-                $expediente->estado = $this->resultado === 'conforme' ? 'Aprobado' : 'Rechazado';
+                $statusName = $this->resultado === 'conforme' ? 'Aprobado' : 'Rechazado';
+                $expediente->status_id = Status::where('name', $statusName)->value('id');
                 $expediente->observaciones = $this->observaciones;
 
                 // ✅ Registrar fecha de validación si es conforme (Aprobado)

--- a/app/Livewire/RemisionExpediente.php
+++ b/app/Livewire/RemisionExpediente.php
@@ -4,6 +4,7 @@ namespace App\Livewire;
 
 use Livewire\Component;
 use App\Models\Expediente;
+use App\Models\Status;
 
 class RemisionExpediente extends Component
 {
@@ -24,7 +25,8 @@ class RemisionExpediente extends Component
     {
         if (!$this->expediente) return;
 
-        $this->expediente->estado = 'Enviado';
+        $enviado = Status::where('name', 'Enviado')->value('id');
+        $this->expediente->status_id = $enviado;
         $this->expediente->medio_envio = $this->medio;
         $this->expediente->fecha_envio = now();
         $this->expediente->save();

--- a/app/Livewire/RevisarExpedientesFinalizados.php
+++ b/app/Livewire/RevisarExpedientesFinalizados.php
@@ -4,6 +4,7 @@ namespace App\Livewire;
 
 use Livewire\Component;
 use Illuminate\Support\Facades\DB;
+use App\Models\Status;
 
 class RevisarExpedientesFinalizados extends Component
 {
@@ -18,11 +19,15 @@ class RevisarExpedientesFinalizados extends Component
 
     public function cargarExpedientes()
     {
+        $canalizado = Status::where('name', 'Canalizado')->value('id');
+        $enviado = Status::where('name', 'Enviado')->value('id');
         $this->expedientes = DB::table('expedientes')
-            ->where(function($query) {
-                $query->where('estado', 'Canalizado')
-                      ->orWhere(function($q) {
-                          $q->where('estado', 'Enviado')
+            ->leftJoin('statuses', 'expedientes.status_id', '=', 'statuses.id')
+            ->select('expedientes.*', 'statuses.name as estado')
+            ->where(function($query) use ($canalizado, $enviado) {
+                $query->where('expedientes.status_id', $canalizado)
+                      ->orWhere(function($q) use ($enviado) {
+                          $q->where('expedientes.status_id', $enviado)
                             ->where('medio_envio', 'Sistema eDoc');
                       });
             })
@@ -32,7 +37,11 @@ class RevisarExpedientesFinalizados extends Component
 
     public function seleccionarExpediente($id)
     {
-        $this->expedienteSeleccionado = DB::table('expedientes')->find($id);
+        $this->expedienteSeleccionado = DB::table('expedientes')
+            ->leftJoin('statuses', 'expedientes.status_id', '=', 'statuses.id')
+            ->select('expedientes.*', 'statuses.name as estado')
+            ->where('expedientes.id', $id)
+            ->first();
         $this->mensajeNotificacion = '';
     }
 
@@ -40,10 +49,11 @@ class RevisarExpedientesFinalizados extends Component
     {
         if ($this->expedienteSeleccionado) {
             // Actualiza estado del expediente
+            $finalizado = Status::where('name', 'Finalizado')->value('id');
             DB::table('expedientes')
                 ->where('id', $this->expedienteSeleccionado->id)
                 ->update([
-                    'estado' => 'Finalizado',
+                    'status_id' => $finalizado,
                     'observaciones' => $this->mensajeNotificacion,
                     'updated_at' => now(),
                 ]);

--- a/app/Livewire/VerificacionExpediente.php
+++ b/app/Livewire/VerificacionExpediente.php
@@ -4,6 +4,7 @@ namespace App\Livewire;
 
 use Livewire\Component;
 use App\Models\Expediente;
+use App\Models\Status;
 
 class VerificacionExpediente extends Component
 {
@@ -12,7 +13,7 @@ class VerificacionExpediente extends Component
 
     public function mount()
     {
-        $this->expedientes = Expediente::all();
+        $this->expedientes = Expediente::with('status')->get();
     }
 
     public function seleccionarExpediente($id)
@@ -23,21 +24,23 @@ class VerificacionExpediente extends Component
     public function validarExpediente()
     {
         if ($this->expedienteSeleccionado) {
-            $this->expedienteSeleccionado->estado = 'Aprobado';
+            $aprobado = Status::where('name', 'Aprobado')->value('id');
+            $this->expedienteSeleccionado->status_id = $aprobado;
             $this->expedienteSeleccionado->fecha_validacion = now();
             $this->expedienteSeleccionado->save();
 
             $this->reset('expedienteSeleccionado');
-            $this->expedientes = Expediente::all();
+            $this->expedientes = Expediente::with('status')->get();
         }
     }
     public function rechazarExpediente(){
         if ($this->expedienteSeleccionado) {
-            $this->expedienteSeleccionado->estado = 'Rechazado';
+            $rechazado = Status::where('name', 'Rechazado')->value('id');
+            $this->expedienteSeleccionado->status_id = $rechazado;
             $this->expedienteSeleccionado->save();
 
             $this->reset('expedienteSeleccionado');
-            $this->expedientes = Expediente::all();
+            $this->expedientes = Expediente::with('status')->get();
         }
     }
 

--- a/app/Models/Expediente.php
+++ b/app/Models/Expediente.php
@@ -2,9 +2,53 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Expediente extends Model
 {
-    //
+    use HasFactory;
+
+    protected $fillable = [
+        'codigo',
+        'solicitante',
+        'dni',
+        'year',
+        'month_id',
+        'fecha_ingreso',
+        'faculty_id',
+        'tramite_type_id',
+        'status_id',
+        'sumilla',
+        'observaciones',
+        'medio_envio',
+        'fecha_envio',
+        'fecha_validacion',
+        'tipo_documento',
+        'area_procedencia',
+        'documento_path',
+        'fecha_archivo',
+        'observacion_archivo',
+        'archivo_cargo'
+    ];
+
+    public function facultad()
+    {
+        return $this->belongsTo(Facultad::class, 'faculty_id');
+    }
+
+    public function month()
+    {
+        return $this->belongsTo(Month::class);
+    }
+
+    public function tramiteType()
+    {
+        return $this->belongsTo(TramiteType::class);
+    }
+
+    public function status()
+    {
+        return $this->belongsTo(Status::class);
+    }
 }

--- a/database/factories/ExpedientesFactory.php
+++ b/database/factories/ExpedientesFactory.php
@@ -3,7 +3,7 @@
 namespace Database\Factories;
 
 use App\Models\TramiteType;
-use App\Models\Expedientes;
+use App\Models\Expediente;
 use App\Models\Facultad;
 use App\Models\Month;
 use App\Models\Status;
@@ -11,17 +11,17 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Str;
 
 /**
- * @extends Factory<\App\Models\Expedientes>
+ * @extends Factory<\App\Models\Expediente>
  */
 class ExpedientesFactory extends Factory
 {
-    protected $model = Expedientes::class;
+    protected $model = Expediente::class;
 
     public function definition(): array
     {
         return [
             'codigo' => strtoupper(Str::random(8)),
-            'name' => $this->faker->name(),
+            'solicitante' => $this->faker->name(),
             'dni' => $this->faker->numerify('########'),
             'year' => $this->faker->numberBetween(2021, 2025),
             'month_id' => Month::inRandomOrder()->value('id'),

--- a/database/migrations/2025_07_20_193222_update_expedientes_table_add_missing_fields.php
+++ b/database/migrations/2025_07_20_193222_update_expedientes_table_add_missing_fields.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('expedientes', function (Blueprint $table) {
+            if (Schema::hasColumn('expedientes', 'name')) {
+                $table->renameColumn('name', 'solicitante');
+            }
+            if (!Schema::hasColumn('expedientes', 'fecha_archivo')) {
+                $table->timestamp('fecha_archivo')->nullable()->after('fecha_envio');
+            }
+            if (!Schema::hasColumn('expedientes', 'observacion_archivo')) {
+                $table->text('observacion_archivo')->nullable()->after('fecha_archivo');
+            }
+            if (!Schema::hasColumn('expedientes', 'archivo_cargo')) {
+                $table->string('archivo_cargo')->nullable()->after('observacion_archivo');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('expedientes', function (Blueprint $table) {
+            if (Schema::hasColumn('expedientes', 'solicitante')) {
+                $table->renameColumn('solicitante', 'name');
+            }
+            if (Schema::hasColumn('expedientes', 'fecha_archivo')) {
+                $table->dropColumn(['fecha_archivo', 'observacion_archivo', 'archivo_cargo']);
+            }
+        });
+    }
+};

--- a/database/seeders/ExpedientesSeeder.php
+++ b/database/seeders/ExpedientesSeeder.php
@@ -4,7 +4,7 @@ namespace Database\Seeders;
 
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
-use App\Models\Expedientes;
+use App\Models\Expediente;
 use App\Models\Facultad;
 
 
@@ -15,6 +15,6 @@ class ExpedientesSeeder extends Seeder
      */
     public function run(): void
     {
-        Expedientes::factory()->count(20)->create();
+        Expediente::factory()->count(20)->create();
     }
 }

--- a/database/seeders/StatusSeeder.php
+++ b/database/seeders/StatusSeeder.php
@@ -2,17 +2,22 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
 class StatusSeeder extends Seeder
 {
-    /**
-     * Run the database seeds.
-     */
     public function run(): void
     {
-        $statuses = ['Enviado', 'Pendiente', 'En Proceso', 'Finalizado', 'Archivado'];
+        $statuses = [
+            'Pendiente',
+            'Progreso',
+            'Aprobado',
+            'Rechazado',
+            'Enviado',
+            'Canalizado',
+            'Finalizado',
+            'Archivado'
+        ];
 
         foreach ($statuses as $name) {
             \App\Models\Status::create(['name' => $name]);

--- a/resources/views/livewire/central-file-filter.blade.php
+++ b/resources/views/livewire/central-file-filter.blade.php
@@ -67,7 +67,7 @@
         <tr class="border-b">
             <td class="px-4 py-2">{{ $file->id }}</td>
             <td class="px-4 py-2">{{ $file->dni }}</td>
-            <td class="px-4 py-2">{{ $file->name }}</td>
+            <td class="px-4 py-2">{{ $file->solicitante }}</td>
             <td class="px-4 py-2">{{ $file->tramiteType->name ?? '-' }}</td>
             <td class="px-4 py-2">{{ $file->facultad->nombre ?? '-' }}</td>
             <td class="px-4 py-2">{{ $file->created_at->format('d/m/Y h:i a') }}</td>

--- a/resources/views/livewire/revisar-expedientes-finalizados.blade.php
+++ b/resources/views/livewire/revisar-expedientes-finalizados.blade.php
@@ -25,7 +25,7 @@
                             <td class="p-2">{{ $exp->codigo }}</td>
                             <td class="p-2">{{ $exp->solicitante }}</td>
                             <td class="p-2">{{ $exp->fecha_ingreso }}</td>
-                            <td class="p-2">{{ $exp->status_id }}</td>
+                            <td class="p-2">{{ $exp->estado }}</td>
                             <td class="p-2">
                                 <button class="btn btn-ver" wire:click="seleccionarExpediente({{ $exp->id }})">
                                     Revisar
@@ -52,7 +52,7 @@
                     <div><strong>N° Expediente:</strong> {{ $expedienteSeleccionado->codigo }}</div>
                     <div><strong>Solicitante:</strong> {{ $expedienteSeleccionado->solicitante }}</div>
                     <div><strong>Fecha Ingreso:</strong> {{ $expedienteSeleccionado->fecha_ingreso }}</div>
-                    <div><strong>Estado Actual:</strong> {{ $expedienteSeleccionado->status_id }}</div>
+                    <div><strong>Estado Actual:</strong> {{ $expedienteSeleccionado->estado }}</div>
                     <div><strong>Observaciones:</strong> {{ $expedienteSeleccionado->observaciones }}</div>
                 </div>
 

--- a/resources/views/livewire/verificacion-expediente.blade.php
+++ b/resources/views/livewire/verificacion-expediente.blade.php
@@ -35,17 +35,17 @@
                 </thead>
                 <tbody>
                     @foreach ($expedientes as $exp)
-                        <tr class="{{$exp->state_id === 'Aprobado' ? 'estado-validado' : ($exp->state_id === 'Rechazado' ? 'estado-rechazado' : 
-                                ($exp->estado === 'Canalizado' ? 'estado-canalizado' : 
-                                ($exp->estado === 'Finalizado' ? 'estado-finalizado' : 
-                                ($exp->estado === 'Archivado' ? 'estado-archivado' : 'estado-pendiente'))))}}">
+                        <tr class="{{$exp->status->name === 'Aprobado' ? 'estado-validado' : ($exp->status->name === 'Rechazado' ? 'estado-rechazado' :
+                                ($exp->status->name === 'Canalizado' ? 'estado-canalizado' :
+                                ($exp->status->name === 'Finalizado' ? 'estado-finalizado' :
+                                ($exp->status->name === 'Archivado' ? 'estado-archivado' : 'estado-pendiente'))))}}">
                             <td class="p-2">{{ $exp->codigo }}</td>
                             <td class="p-2">{{ $exp->solicitante }}</td>
                             <td class="p-2">{{ $exp->fecha_ingreso }}</td>
-                            <td class="p-2">{{ $exp->estado }}</td>
+                            <td class="p-2">{{ $exp->status->name }}</td>
                             <td class="p-2 flex gap-2">
                                 <button class="btn-ver" wire:click="seleccionarExpediente({{ $exp->id }})">Ver</button>
-                                @if ($exp->estado === 'En Curso')
+                                @if ($exp->status->name === 'En Curso' || $exp->status->name === 'Progreso')
                                     <a href="{{ route('registroObservaciones', ['expedienteId' => $exp->id]) }}"
                                        class="btn-observar bg-blue-500 text-white px-2 py-1 rounded text-sm hover:bg-blue-600">
                                         Observar
@@ -68,10 +68,10 @@
                     <div><strong>Solicitante:</strong> {{ $expedienteSeleccionado->solicitante }}</div>
                     <div><strong>Fecha Ingreso:</strong> {{ $expedienteSeleccionado->fecha_ingreso }}</div>
                     <div><strong>Sumilla:</strong> {{ $expedienteSeleccionado->sumilla }}</div>
-                    <div><strong>Estado:</strong> {{ $expedienteSeleccionado->estado }}</div>
+                    <div><strong>Estado:</strong> {{ $expedienteSeleccionado->status->name }}</div>
                 </div>
 
-                @if ($expedienteSeleccionado->estado === 'En Curso')
+                @if ($expedienteSeleccionado->status->name === 'En Curso' || $expedienteSeleccionado->status->name === 'Progreso')
                     <div class="acciones flex gap-4">
                         <button wire:click="validarExpediente"
                                 class="btn validar-btn bg-green-600 text-white px-4 py-2 rounded">
@@ -82,7 +82,7 @@
                             RECHAZAR
                         </button>
                     </div>
-                @elseif ($expedienteSeleccionado->estado === 'Aprobado')
+                @elseif ($expedienteSeleccionado->status->name === 'Aprobado')
                     <div class="acciones mt-4">
                         <a href="{{ route('remisionExpediente', ['expedienteId' => $expedienteSeleccionado->id]) }}"
                            class="btn btn-remitir bg-indigo-600 text-white px-4 py-2 rounded hover:bg-indigo-700">

--- a/tests/Feature/DatabaseStructureTest.php
+++ b/tests/Feature/DatabaseStructureTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+class DatabaseStructureTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_expedientes_table_has_expected_columns(): void
+    {
+        $this->assertTrue(Schema::hasColumns('expedientes', [
+            'solicitante',
+            'fecha_archivo',
+            'observacion_archivo',
+            'archivo_cargo'
+        ]));
+    }
+}


### PR DESCRIPTION
## Summary
- rename `name` to `solicitante` and add missing fields to expedientes
- expand default statuses
- ensure Eloquent model exposes all columns
- update Livewire components to use status IDs
- adjust Blade views to match database columns
- update factories and seeders
- add database structure test

## Testing
- `composer install`
- `php artisan key:generate`
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_687d895fc2088327946d22f8a7b961f7