### PR TITLE
Add funcionario role views

### DIFF
--- a/database/seeders/DefaultUsersSeeder.php
+++ b/database/seeders/DefaultUsersSeeder.php
@@ -36,5 +36,14 @@ class DefaultUsersSeeder extends Seeder
             'password' => Hash::make('password'),
             'role_id' => 4,
         ]);
+
+        User::create([
+            'name' => 'Funcionario',
+            'last_name' => 'User',
+            'dni' => '00000004',
+            'email' => 'funcionario@example.com',
+            'password' => Hash::make('password'),
+            'role_id' => 3,
+        ]);
     }
 }

--- a/resources/views/components/layouts/app/sidebar.blade.php
+++ b/resources/views/components/layouts/app/sidebar.blade.php
@@ -37,12 +37,14 @@
                         <flux:navlist.item icon="arrow-right-circle" :href="route('tramite.proceso')" :current="request()->routeIs('tramite.proceso')" wire:navigate>{{ __('Trámite en Proceso') }}</flux:navlist.item>
                         <flux:navlist.item icon="document-check" :href="route('tramite.finalizado')" :current="request()->routeIs('tramite.finalizado')" wire:navigate>{{ __('Trámite Finalizado') }}</flux:navlist.item>
                     @endif
-                <flux:navlist.group class="grid">
-                    <flux:navlist.item icon="home" :href="route('dashboard')" :current="request()->routeIs('dashboard')" wire:navigate>{{ __('Dashboard no usar') }}</flux:navlist.item>
-                    <flux:navlist.item icon="home" :href="route('panel.principal')" :current="request()->routeIs('panel.principal')" wire:navigate>{{ __('Panel principal') }}</flux:navlist.item>
-                    <!--<flux:navlist.item icon="document" :href="route('mis.asignaciones')" :current="request()->routeIs('mis.asignaciones')" wire:navigate>{{ __('Mis asignaciones') }}</flux:navlist.item>-->
-                    <flux:navlist.item icon="paper-airplane" :href="route('bandeja.salida')" :current="request()->routeIs('bandeja.salida')" wire:navigate>Bandeja de Salida</flux:navlist.item>
-                </flux:navlist.group>
+                @if ($role === 'funcionario')
+                    <flux:navlist.group class="grid">
+                        <flux:navlist.item icon="home" :href="route('dashboard')" :current="request()->routeIs('dashboard')" wire:navigate>{{ __('Dashboard no usar') }}</flux:navlist.item>
+                        <flux:navlist.item icon="home" :href="route('panel.principal')" :current="request()->routeIs('panel.principal')" wire:navigate>{{ __('Panel principal') }}</flux:navlist.item>
+                        <!--<flux:navlist.item icon="document" :href="route('mis.asignaciones')" :current="request()->routeIs('mis.asignaciones')" wire:navigate>{{ __('Mis asignaciones') }}</flux:navlist.item>-->
+                        <flux:navlist.item icon="paper-airplane" :href="route('bandeja.salida')" :current="request()->routeIs('bandeja.salida')" wire:navigate>Bandeja de Salida</flux:navlist.item>
+                    </flux:navlist.group>
+                @endif
             </flux:navlist>
 
             <flux:spacer />

--- a/resources/views/livewire/mis-asignaciones.blade.php
+++ b/resources/views/livewire/mis-asignaciones.blade.php
@@ -1,0 +1,3 @@
+<div class="p-6">
+    <h1 class="text-2xl font-semibold mb-4">Mis Asignaciones</h1>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -12,6 +12,7 @@ use App\Livewire\RevisarExpedientesFinalizados;
 use App\Livewire\NotificacionesSolicitante;
 use App\Livewire\EntregarArchivar;
 use App\Livewire\PanelSeguimiento;
+use App\Livewire\MisAsignaciones;
 use App\Http\Controllers\G1_DocumentosController;
 use App\Livewire\CentralFileFilter;
 use App\Livewire\DerivarTramite;
@@ -74,27 +75,23 @@ Route::middleware(['auth', 'verified', 'role:administrador'])->group(function ()
         ->name('bandeja.entrada');
 });
 
-Route::view('mis_asignaciones', 'mis_asignaciones')
-    ->middleware(['auth', 'verified'])
-    ->name('mis.asignaciones');
+Route::middleware(['auth', 'verified', 'role:funcionario'])->group(function () {
+    Route::get('mis_asignaciones', MisAsignaciones::class)
+        ->name('mis.asignaciones');
 
-Route::view('panel_principal', 'panel_principal')
-    ->middleware(['auth', 'verified'])
-    ->name('panel.principal');
+    Route::view('panel_principal', 'Funcionario.panel_principal')
+        ->name('panel.principal');
 
-// bandeja salida
-Route::view('bandeja_salida', 'bandeja_salida')
-    ->middleware(['auth', 'verified'])
-    ->name('bandeja.salida');
+    // bandeja salida
+    Route::view('bandeja_salida', 'Funcionario.bandeja_salida')
+        ->name('bandeja.salida');
 
+    Route::view('perfil/editar', 'Funcionario.editar-perfil')
+        ->name('perfil.editar');
 
-Route::view('perfil/editar', 'editar-perfil')
-    ->middleware(['auth', 'verified'])
-    ->name('perfil.editar');
-
-Route::get('tramites/{tramiteId}/derivar', DerivarTramite::class)
-    ->middleware(['auth', 'verified'])
-    ->name('derivar.tramite');
+    Route::get('tramites/{tramiteId}/derivar', DerivarTramite::class)
+        ->name('derivar.tramite');
+});
 
 
 Route::middleware(['auth'])->group(function () {


### PR DESCRIPTION
## Summary
- add `MisAsignaciones` Livewire view
- restrict Funcionario-only routes and use correct blade paths
- show Funcionario links in sidebar only for that role
- seed a default funcionario user

## Testing
- `composer test` *(fails: table "notificaciones" already exists)*

------
https://chatgpt.com/codex/tasks/task_e_687dbb23ebb48327bc160b3964a6434d