### PR TITLE
Add missing routes and sidebar entries

### DIFF
--- a/app/Http/Controllers/TramiteController.php
+++ b/app/Http/Controllers/TramiteController.php
@@ -162,6 +162,6 @@ class TramiteController extends Controller
             }
         }
 
-        return redirect()->route('tramites.lista')->with('success', 'Solicitud enviada correctamente.');
+        return redirect()->route('tramites.index')->with('success', 'Solicitud enviada correctamente.');
     }
 }

--- a/resources/views/ampliacion_plazo.blade.php
+++ b/resources/views/ampliacion_plazo.blade.php
@@ -1,3 +1,3 @@
-<x-layouts.app :title="__('Ampliación de Plazo para Culminación de Ejcución de Tesis')">
+<x-layouts.app :title="__('Ampliación de Plazo para Culminación de Ejecución de Tesis')">
     @livewire('ampliacion_plazo_livewire')
 </x-layouts.app>

--- a/resources/views/components/layouts/app/sidebar.blade.php
+++ b/resources/views/components/layouts/app/sidebar.blade.php
@@ -13,24 +13,17 @@
 
             <flux:navlist variant="outline">
                 <flux:navlist.group class="grid">
-                    <flux:navlist.item icon="home" :href="route('dashboard')" :current="request()->routeIs('dashboard')" wire:navigate>{{ __('Dashboard no usar') }}</flux:navlist.item>
-                    <flux:navlist.item icon="home" :href="route('ejemplo.dashboard')" :current="request()->routeIs('ejemplo.dashboard')" wire:navigate>{{ __('Dashboard') }}</flux:navlist.item>
-                    <flux:navlist.item icon="document" :href="route('ejemplo')" :current="request()->routeIs('ejemplo')" wire:navigate>{{ __('Ejemplo') }}</flux:navlist.item>
+                    <flux:navlist.item icon="home" :href="route('dashboard')" :current="request()->routeIs('dashboard')" wire:navigate>{{ __('Dashboard') }}</flux:navlist.item>
+                    <flux:navlist.item icon="home" :href="route('ejemplo.dashboard')" :current="request()->routeIs('ejemplo.dashboard')" wire:navigate>{{ __('Ejemplo Dashboard') }}</flux:navlist.item>
+                    <flux:navlist.item icon="document" :href="route('ejemplo')" :current="request()->routeIs('ejemplo')" wire:navigate>{{ __('Derivar') }}</flux:navlist.item>
+                    <flux:navlist.item icon="document" :href="route('ampliacion_plazo')" :current="request()->routeIs('ampliacion_plazo')" wire:navigate>{{ __('Ampliación de Plazo') }}</flux:navlist.item>
+                    <flux:navlist.item icon="document" :href="route('cambio_titulo_asesor')" :current="request()->routeIs('cambio_titulo_asesor')" wire:navigate>{{ __('Cambio de Título o Asesor') }}</flux:navlist.item>
+                    <flux:navlist.item icon="document" :href="route('otros_tramites')" :current="request()->routeIs('otros_tramites')" wire:navigate>{{ __('Otros Trámites') }}</flux:navlist.item>
+                    <flux:navlist.item icon="document" :href="route('tramites.index')" :current="request()->routeIs('tramites.*')" wire:navigate>{{ __('Trámites') }}</flux:navlist.item>
                 </flux:navlist.group>
             </flux:navlist>
 
             <flux:spacer />
-<!--
-            <flux:navlist vari  ant="outline">
-                <flux:navlist.item icon="folder-git-2" href="https://github.com/laravel/livewire-starter-kit" target="_blank">
-                {{ __('Repository') }}
-                </flux:navlist.item>
-
-                <flux:navlist.item icon="book-open-text" href="https://laravel.com/docs/starter-kits#livewire" target="_blank">
-                {{ __('Documentation') }}
-                </flux:navlist.item>
-            </flux:navlist>
--->
             <!-- Desktop User Menu -->
             <flux:dropdown class="hidden lg:block" position="bottom" align="start">
                 <flux:profile

--- a/resources/views/ejemplo_dashboard.blade.php
+++ b/resources/views/ejemplo_dashboard.blade.php
@@ -1,3 +1,3 @@
-<x-layouts.app :title="__('Nombre tittle')">
+<x-layouts.app :title="__('Ejemplo Dashboard')">
     <h1>Ejemplo Dashboard</h1>
 </x-layouts.app>

--- a/resources/views/otros_tramites.blade.php
+++ b/resources/views/otros_tramites.blade.php
@@ -1,3 +1,3 @@
-<x-layouts.app :title="__('Otros Tramites')">
+<x-layouts.app :title="__('Otros Trámites')">
     @livewire('otros_tramites_livewire')
 </x-layouts.app>

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,35 +2,20 @@
 
 use Illuminate\Support\Facades\Route;
 use Livewire\Volt\Volt;
+use App\Http\Controllers\TramiteController;
 
 Route::get('/', function () {
     return view('welcome');
 })->name('home');
 
-Route::view('dashboard', 'dashboard')
-    ->middleware(['auth', 'verified'])
-    ->name('dashboard');
-
-Route::view('ejemplo', 'ejemplo')
-    ->middleware(['auth', 'verified'])
-    ->name('ejemplo');
-
-Route::view('ejemplo_dashboard', 'ejemplo_dashboard')
-    ->middleware(['auth', 'verified'])
-    ->name('ejemplo.dashboard');
-
-
-Route::view('ampliacion_plazo', 'ampliacion_plazo')
-    ->middleware(['auth', 'verified'])
-    ->name('ampliacion_plazo');
-
-Route::view('cambio_titulo_asesor', 'cambio_titulo_asesor')
-    ->middleware(['auth', 'verified'])
-    ->name('cambio_titulo_asesor');
-
-Route::view('otros_tramites', 'otros_tramites')
-    ->middleware(['auth', 'verified'])
-    ->name('otros_tramites');
+Route::middleware(['auth', 'verified'])->group(function () {
+    Route::view('dashboard', 'dashboard')->name('dashboard');
+    Route::view('ejemplo', 'ejemplo')->name('ejemplo');
+    Route::view('ejemplo_dashboard', 'ejemplo_dashboard')->name('ejemplo.dashboard');
+    Route::view('ampliacion_plazo', 'ampliacion_plazo')->name('ampliacion_plazo');
+    Route::view('cambio_titulo_asesor', 'cambio_titulo_asesor')->name('cambio_titulo_asesor');
+    Route::view('otros_tramites', 'otros_tramites')->name('otros_tramites');
+});
 
 
 Route::middleware(['auth'])->group(function () {
@@ -43,8 +28,7 @@ Route::middleware(['auth'])->group(function () {
 
 require __DIR__.'/auth.php';
 
-//Tramites 
-use App\Http\Controllers\TramiteController;
+// Tramites
 
 Route::get('/tramites', [TramiteController::class, 'listaTramites'])->name('tramites.index');
 Route::get('/tramites/{id}', [TramiteController::class, 'show'])->name('tramites.show');


### PR DESCRIPTION
## Summary
- register TramiteController at top of routes file and group view routes
- link Tramite list after form submissions
- fix typos in several blade views
- add every page to the sidebar navigation

## Testing
- `php artisan route:list | head -n 20`
- `./vendor/bin/phpunit` *(fails: No application encryption key)*

------
https://chatgpt.com/codex/tasks/task_e_687dda95144c8327ab0de838942ef13f