### PR TITLE
Add dynamic form-tramite view

### DIFF
--- a/app/Livewire/FormTramite.php
+++ b/app/Livewire/FormTramite.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Livewire;
+
+use Livewire\Component;
+use Livewire\WithFileUploads;
+use App\Models\TramiteType;
+use App\Models\DetalleTramite;
+
+class FormTramite extends Component
+{
+    use WithFileUploads;
+
+    public $tramiteId;
+    public $tramiteName;
+    public $requisitos = [];
+    public $detalles;
+    public $sustento;
+    public $archivos = [];
+
+    public function mount($tramite)
+    {
+        $this->tramiteId = $tramite;
+
+        $type = TramiteType::find($tramite);
+        $this->tramiteName = $type?->name;
+
+        $this->detalles = DetalleTramite::find($tramite);
+
+        $modelo = "\\App\\Models\\Requisito{$tramite}";
+        if (class_exists($modelo)) {
+            $this->requisitos = $modelo::orderBy('id')->pluck('descripcion')->toArray();
+        }
+    }
+
+    public function rules()
+    {
+        $rules = [
+            'sustento' => 'required|string|max:255',
+        ];
+        foreach ($this->requisitos as $index => $req) {
+            $rules["archivos.$index"] = 'required|file|max:5120';
+        }
+        return $rules;
+    }
+
+    public function enviarSolicitud()
+    {
+        $this->validate();
+        foreach ($this->archivos as $archivo) {
+            $archivo->store('tramites');
+        }
+        session()->flash('message', 'Solicitud enviada correctamente.');
+        $this->reset(['sustento','archivos']);
+    }
+
+    public function volver()
+    {
+        return redirect()->route('tramites.lista');
+    }
+
+    public function render()
+    {
+        return view('livewire.form-tramite');
+    }
+}

--- a/app/Livewire/TramitesLista.php
+++ b/app/Livewire/TramitesLista.php
@@ -3,54 +3,20 @@
 namespace App\Livewire;
 
 use Livewire\Component;
+use App\Models\TramiteType;
 
 class TramitesLista extends Component
 {
-    public $types = [
-        'Constancia de expedito para optar título profesional',
-        'Constancia de expedito para grado de bachiller',
-        'Constancia de prácticas preprofesionales/internado',
-        'Constancia de inscripción, aprobación y asesoramiento del plan de tesis',
-        'Constancia de egresado (bachiller y título profesional)',
-        'Certificado de estudios de pregrado (formato 1)',
-        'Certificado de prácticas preprofesionales y profesionales',
-        'Constancia de récord académico, estudios, matrícula y otros',
-        'Constancia con orden de mérito: décimo, quinto, tercio superior',
-        'Cambio de título del plan de tesis / Cambio de asesor',
-        'Ampliación de plazo para conclusión de ejecución de tesis',
-        'Otorgar el título profesional',
-        'Otorgar grado académico de maestro, doctor y título de segunda especialidad profesional',
-        'Otros trámites',
-    ];
+    public $types = [];
 
-    public function verDetalle($tramite)
+    public function mount()
     {
-        // Mapeo de trámites a sus rutas correspondientes
-        $rutasTramites = [
-            'Constancia de expedito para optar título profesional' => 'constancia_expedito_profesional',
-            'Constancia de expedito para grado de bachiller' => 'constancia_expedito_bachiller',
-            'Constancia de prácticas preprofesionales/internado' => 'constancia_practicas_preprofesionales',
-            'Constancia de inscripción, aprobación y asesoramiento del plan de tesis' => 'constancia_plan_tesis',
-            'Constancia de egresado (bachiller y título profesional)' => 'constancia_egresado',
-            'Certificado de estudios de pregrado (formato 1)' => 'certificado_estudios_pregrado',
-            'Certificado de prácticas preprofesionales y profesionales' => 'certificado_practicas',
-            'Constancia de récord académico, estudios, matrícula y otros' => 'constancia_record_academico',
-            'Constancia con orden de mérito: décimo, quinto, tercio superior' => 'constancia_orden_merito',
-            'Cambio de título del plan de tesis / Cambio de asesor' => 'cambio_titulo_asesor',
-            'Ampliación de plazo para conclusión de ejecución de tesis' => 'ampliacion_plazo_tesis',
-            'Otorgar el título profesional' => 'otorgar_titulo_profesional',
-            'Otorgar grado académico de maestro, doctor y título de segunda especialidad profesional' => 'otorgar_grado_academico',
-            'Otros trámites' => 'otros_tramites',
-        ];
+        $this->types = TramiteType::orderBy('id')->pluck('name')->toArray();
+    }
 
-        // Verificar si existe la ruta para el trámite seleccionado
-        if (isset($rutasTramites[$tramite])) {
-            // Usar redirectRoute en lugar de redirect()->route() para Livewire
-            $this->redirectRoute($rutasTramites[$tramite]);
-        } else {
-            // Si no existe la ruta, mostrar mensaje
-            session()->flash('message', 'Este trámite estará disponible próximamente');
-        }
+    public function verDetalle($tramiteId)
+    {
+        $this->redirectRoute('form.tramite', ['tramite' => $tramiteId]);
     }
 
     public function render()

--- a/resources/views/livewire/form-tramite.blade.php
+++ b/resources/views/livewire/form-tramite.blade.php
@@ -1,0 +1,45 @@
+<div class="w-full max-w-3xl mx-auto p-6 bg-white rounded-md shadow">
+    <h1 class="text-xl font-bold text-yellow-600 text-center mb-4">{{ $tramiteName }}</h1>
+
+    @if($detalles)
+        <div class="mb-4 text-sm">
+            <p><strong>Duración:</strong> {{ $detalles->duracion }} días</p>
+            <p><strong>Área de inicio:</strong> {{ $detalles->area_inicio }}</p>
+        </div>
+    @endif
+
+    <div class="mb-4">
+        <h2 class="font-bold mb-2 text-sm">Requisitos:</h2>
+        <ol class="list-decimal list-inside text-xs space-y-1">
+            @foreach($requisitos as $req)
+                <li>{{ $req }}</li>
+            @endforeach
+        </ol>
+    </div>
+
+    <div class="mb-4">
+        <label class="block text-sm font-medium mb-1">Sustento</label>
+        <textarea wire:model.defer="sustento" class="w-full border rounded p-2 text-sm"></textarea>
+        @error('sustento')<span class="text-red-600 text-xs">{{ $message }}</span>@enderror
+    </div>
+
+    <div class="mb-4">
+        <h2 class="font-bold text-sm mb-2">Archivos</h2>
+        @foreach($requisitos as $index => $req)
+            <div class="mb-2">
+                <label class="block text-xs mb-1">{{ $req }}</label>
+                <input type="file" wire:model="archivos.{{ $index }}" class="w-full border rounded p-1 text-xs" />
+                @error("archivos.$index")<span class="text-red-600 text-xs">{{ $message }}</span>@enderror
+            </div>
+        @endforeach
+    </div>
+
+    <div class="text-center">
+        <button wire:click="enviarSolicitud" class="px-4 py-2 bg-green-600 text-white rounded">Enviar solicitud</button>
+        <button wire:click="volver" class="ml-2 px-4 py-2 bg-gray-200 text-gray-700 rounded">Volver</button>
+    </div>
+
+    @if (session()->has('message'))
+        <div class="mt-4 p-2 bg-green-100 text-green-700 rounded text-sm">{{ session('message') }}</div>
+    @endif
+</div>

--- a/resources/views/livewire/tramites-lista.blade.php
+++ b/resources/views/livewire/tramites-lista.blade.php
@@ -26,8 +26,8 @@
                     </div>
 
                     <div class="flex-shrink-0">
-                        <button 
-                            wire:click="verDetalle('{{ $tramite}}')"
+                        <button
+                            wire:click="verDetalle({{ $index + 1 }})"
                             class="bg-green-600 hover:bg-green-700 text-white font-medium py-2 px-4 rounded-lg text-sm transition duration-200 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2">
                             Detalle
                         </button>

--- a/routes/web.php
+++ b/routes/web.php
@@ -31,6 +31,12 @@ Route::view('tramites_lista', 'tramites_lista')
     ->middleware(['auth', 'verified'])
     ->name('tramites.lista');
 
+use App\Livewire\FormTramite;
+
+Route::get('form-tramite/{tramite}', FormTramite::class)
+    ->middleware(['auth', 'verified'])
+    ->name('form.tramite');
+
 Route::middleware(['auth', 'verified', 'role:operador'])->group(function () {
     Route::get('/verificacion-expediente', VerificacionExpediente::class)
         ->name('verificacionExpediente');


### PR DESCRIPTION
## Summary
- add `FormTramite` Livewire component
- query tramite types from DB in `TramitesLista`
- redirect to `form-tramite/{id}`
- create dynamic form view and route

## Testing
- `vendor/bin/phpunit --version` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687efc153c208327a6de147540b3ca5c